### PR TITLE
feat: add CI/CD pipeline configuration for backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/path zricethezav/gitleaks:latest detect --source /path --exit-code 1
 
   docker-build-push:
     runs-on: self-hosted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI/CD Backend
+
+on:
+  push:
+    branches:
+      - main
+      - development
+  pull_request:
+    branches:
+      - main
+      - development
+
+jobs:
+  compile:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Compile
+        run: |
+          chmod +x ./mvnw
+          ./mvnw compile -Dmaven.repo.local=.m2/repository
+
+  secret-detection:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-build-push:
+    runs-on: self-hosted
+    needs: [compile, secret-detection]
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - name: Login to ECR
+        run: |
+          aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
+      - name: Build and push
+        run: |
+          IMAGE_TAG=${{ secrets.ECR_REGISTRY }}/salespilot/api:${{ github.sha }}
+          docker build -t $IMAGE_TAG .
+          docker push $IMAGE_TAG
+
+  deploy:
+    runs-on: self-hosted
+    needs: docker-build-push
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy via SSH
+        run: |
+          echo "${{ secrets.EC2_SSH_KEY }}" > /tmp/deploy_key.pem
+          chmod 400 /tmp/deploy_key.pem
+          ssh -o StrictHostKeyChecking=no -i /tmp/deploy_key.pem ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} "
+            cd salespilot &&
+            aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }} &&
+            export IMAGE_TAG=${{ secrets.ECR_REGISTRY }}/salespilot/api:${{ github.sha }} &&
+            docker compose -f docker-compose.prod.yml pull &&
+            docker compose -f docker-compose.prod.yml up -d
+          "
+          rm /tmp/deploy_key.pem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: 'maven'
       - name: Compile
         run: |
           chmod +x ./mvnw
@@ -62,14 +63,14 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy via SSH
-        run: |
-          echo "${{ secrets.EC2_SSH_KEY }}" > /tmp/deploy_key.pem
-          chmod 400 /tmp/deploy_key.pem
-          ssh -o StrictHostKeyChecking=no -i /tmp/deploy_key.pem ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} "
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
             cd salespilot &&
             aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }} &&
             export IMAGE_TAG=${{ secrets.ECR_REGISTRY }}/salespilot/api:${{ github.sha }} &&
             docker compose -f docker-compose.prod.yml pull &&
             docker compose -f docker-compose.prod.yml up -d
-          "
-          rm /tmp/deploy_key.pem


### PR DESCRIPTION
## Issue relacionada

N/A

## O que foi implementado?

Adicionado o arquivo .github/workflows/ci.yml no repositório do backend. O pipeline conta com as stages de compile (compilação do projeto com Maven), secret-detection (detecção de secrets com Gitleaks), docker-build-push (build e push da imagem para o ECR em salespilot/api) e deploy (acesso à EC2 de produção via SSH, pull da imagem atualizada e reinício dos containers com docker-compose.prod.yml). As stages de docker e deploy rodam apenas em merges na main.

## Por que essa mudança é necessária?

Para automatizar o build, entrega e deploy da aplicação a cada merge na `main`, eliminando a necessidade de intervenção manual no servidor de produção.

## Como testar?

Abrir um PR apontando para `main` e verificar se as stages de `compile` e `secret-detection` rodam. Após merge na `main`, verificar se as stages `docker-build-push` e `deploy` executam com sucesso e se a aplicação está acessível no IP da EC2 de produção.

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o PR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças