### PR TITLE
fix: company creation returning null plan and timestamps

### DIFF
--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
@@ -74,12 +74,13 @@ public class CompanyRepositoryImpl implements CompanyRepository {
     @Transactional
     @Override
     public Company createCompany(String name, String taxId, String plan, boolean active) {
-        CompanyEntity entity = companyJpaRepository.save(new CompanyEntity(name, taxId, active));
-        createSubscription(entity, plan);
+        CompanyEntity entity = companyJpaRepository.saveAndFlush(new CompanyEntity(name, taxId, active));
+        CompanySubscriptions subscription = createSubscription(entity, plan);
+        entity.getSubscriptions().add(subscription);
         return mapper.toDomain(entity);
     }
 
-    private void createSubscription(CompanyEntity company, String planName) {
+    private CompanySubscriptions createSubscription(CompanyEntity company, String planName) {
         SubscriptionPlans plan = subscriptionPlansJpaRepository
                 .findByNameIgnoreCase(planName)
                 .orElseThrow(() -> new IllegalArgumentException("Plano não encontrado: " + planName));
@@ -92,7 +93,7 @@ public class CompanyRepositoryImpl implements CompanyRepository {
         subscription.setStartsAt(LocalDateTime.now());
         subscription.setCreatedAt(LocalDateTime.now());
         subscription.setUpdatedAt(LocalDateTime.now());
-        companySubscriptionsJpaRepository.save(subscription);
+        return companySubscriptionsJpaRepository.save(subscription);
     }
 
     private void updateSubscription(CompanyEntity company, String planName) {


### PR DESCRIPTION
## Issue relacionada                        
                                                                                                                                                                                                                                 
  N/A
                                                                                                                                                                                                                                 
  ## O que foi implementado?                  
 Corrigidos dois bugs no endpoint `POST /api/companies` que faziam os campos                                                                                                                                             `plan`, `created_at` e `updated_at` retornarem `null` na resposta de criação.
                                                                                                                                                                                                                                 
  **Problema 1 — `plan` null:**                                                                                                                                                                                                  
  Após salvar a `CompanyEntity`, a subscription era persistida separadamente via                                                                                                                                                 
  `companySubscriptionsJpaRepository.save()`, mas a lista `entity.subscriptions`                                                                                                                                                 
  em memória continuava vazia (é um `ArrayList` inicializado no construtor, não                                                                                                                                                  
  um proxy lazy). O mapper iterava essa lista vazia e não encontrava nenhuma                                                                                                                                                     
  subscription ativa.                                                                                                                                                                                                            
                                                                                                                                                                                                                                 
  **Correção:** `createSubscription` agora retorna a entidade salva, que é                                                                                                                                                       
  adicionada à lista em memória antes de mapear (consistência bidirecional).
                                                                                                                                                                                                                                 
  **Problema 2 — `created_at` / `updated_at` null:**                                                                                                                                                                             
  O `@CreationTimestamp` do Hibernate popula os campos durante o flush, não no                                                                                                                                                   
  `persist()`. Como `save()` apenas agenda o INSERT sem executá-lo, os campos                                                                                                                                                    
  ainda estavam null no momento do mapeamento.                                                                                                                                                                                   
                                                                                                                                                                                                                                 
  **Correção:** Substituído `save()` por `saveAndFlush()`, forçando o INSERT                                                                                                                                                     
  imediato e garantindo que os timestamps estejam preenchidos na entidade.                                                                                                                                                       
                                                                                                                                                                                                                                 
  ## Por que essa mudança é necessária?       
                                                                                                                                                                                                                                 
  A resposta do endpoint de criação de empresa retornava dados incompletos,                                                                                                                                                      
  exigindo uma segunda requisição para obter o estado real do recurso criado.
                                                                                                                                                                                                                                 
  ## Como testar?                             
                                                                                                                                                                                                                                 
                        
  curl -X POST 'http://localhost:8080/api/companies' \
    -H 'Content-Type: application/json' \
    -d '{"name":"Empresa X","tax_id":"12345","plan":"BASIC","active":true}'

                                                                                                                                                                                                                                 
  A resposta deve conter plan, created_at e updated_at preenchidos.                                                                                                                                                              
                                                                                                                                                                                                                                 
 ## Checklist                                                                                                                                                                                                                      
                                              
  - [X] O código foi revisado pelo próprio autor antes de abrir o MR                                                                                                                                                                 
  - [X] A implementação não quebra funcionalidades existentes
  - [ ] Testes foram adicionados ou atualizados para cobrir as mudanças