### PR TITLE
feat: get meeting context and metadata

### DIFF
--- a/application/src/main/java/com/salespilot/api/application/dto/MeetingContextMetadataResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/MeetingContextMetadataResponseDTO.java
@@ -1,0 +1,24 @@
+package com.salespilot.api.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record MeetingContextMetadataResponseDTO(
+        UUID id,
+        String title,
+        String status,
+        String meetingType,
+        String objective,
+        String clientNeeds,
+        String previousInteractions,
+        String competitorsInvolved,
+        LocalDateTime scheduledFor,
+        LocalDateTime startedAt,
+        LocalDateTime endedAt,
+        Integer durationSeconds,
+        SellerMeetingResponseDTO seller,
+        ClientMeetingResponseDTO client,
+        MeetingPreAnalysisResponseDTO preAnalysis,
+        LocalDateTime createdAt
+) {
+}

--- a/application/src/main/java/com/salespilot/api/application/dto/MeetingPreAnalysisResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/MeetingPreAnalysisResponseDTO.java
@@ -1,0 +1,26 @@
+package com.salespilot.api.application.dto;
+
+import com.salespilot.api.domain.entity.MeetingPreAnalysis;
+import com.salespilot.api.domain.valueobject.PreAnalysisRecommendedStrategy;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record MeetingPreAnalysisResponseDTO(
+        UUID id,
+        PreAnalysisRecommendedStrategy recommendedStrategy,
+        List<String> keyPoints,
+        List<String> possibleObjections,
+        LocalDateTime createdAt
+) {
+    public static MeetingPreAnalysisResponseDTO from (MeetingPreAnalysis meetingPreAnalysis) {
+        return new MeetingPreAnalysisResponseDTO(
+                meetingPreAnalysis.getId(),
+                meetingPreAnalysis.getRecommendedStrategy(),
+                meetingPreAnalysis.getKeyPoints().keyPoints(),
+                meetingPreAnalysis.getPossibleObjections().possibleObjections(),
+                meetingPreAnalysis.getCreatedAt()
+        );
+    }
+}

--- a/application/src/main/java/com/salespilot/api/application/exception/MeetingNotFoundException.java
+++ b/application/src/main/java/com/salespilot/api/application/exception/MeetingNotFoundException.java
@@ -1,0 +1,9 @@
+package com.salespilot.api.application.exception;
+
+import java.util.UUID;
+
+public class MeetingNotFoundException extends RuntimeException{
+    public MeetingNotFoundException(UUID meetingId) {
+        super("Meeting not found. ID: " + meetingId);
+    }
+}

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetMeetingContextAndMetadataUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetMeetingContextAndMetadataUseCase.java
@@ -1,0 +1,70 @@
+package com.salespilot.api.application.usecase;
+
+import com.salespilot.api.application.dto.ClientMeetingResponseDTO;
+import com.salespilot.api.application.dto.MeetingContextMetadataResponseDTO;
+import com.salespilot.api.application.dto.MeetingPreAnalysisResponseDTO;
+import com.salespilot.api.application.dto.SellerMeetingResponseDTO;
+import com.salespilot.api.application.exception.ClientNotFoundException;
+import com.salespilot.api.application.exception.CollaboratorNotFoundException;
+import com.salespilot.api.application.exception.MeetingNotFoundException;
+import com.salespilot.api.domain.entity.Collaborator;
+import com.salespilot.api.domain.entity.Meeting;
+import com.salespilot.api.domain.repository.ClientRepository;
+import com.salespilot.api.domain.repository.CollaboratorRepository;
+import com.salespilot.api.domain.repository.MeetingPreAnalysisRepository;
+import com.salespilot.api.domain.repository.MeetingRepository;
+
+import java.util.UUID;
+
+public class GetMeetingContextAndMetadataUseCase {
+    private final MeetingRepository repository;
+    private final CollaboratorRepository collaboratorRepository;
+    private final ClientRepository clientRepository;
+    private final MeetingPreAnalysisRepository meetingPreAnalysisRepository;
+
+    public GetMeetingContextAndMetadataUseCase(MeetingRepository repository, CollaboratorRepository collaboratorRepository, ClientRepository clientRepository, MeetingPreAnalysisRepository meetingPreAnalysisRepository) {
+        this.repository = repository;
+        this.collaboratorRepository = collaboratorRepository;
+        this.clientRepository = clientRepository;
+        this.meetingPreAnalysisRepository = meetingPreAnalysisRepository;
+    }
+
+    public MeetingContextMetadataResponseDTO execute(UUID meetingId) {
+        Meeting meeting = repository.getMeetingById(meetingId)
+                .orElseThrow(() -> new MeetingNotFoundException(meetingId));
+
+        SellerMeetingResponseDTO seller = collaboratorRepository
+                .getCollaboratorById(meeting.getCollaboratorId())
+                .map(SellerMeetingResponseDTO::from)
+                .orElseThrow(() -> new CollaboratorNotFoundException(meeting.getCollaboratorId()));
+
+        ClientMeetingResponseDTO client = clientRepository
+                .findById(meeting.getClientId())
+                .map(ClientMeetingResponseDTO::from)
+                .orElseThrow(() -> new ClientNotFoundException(meeting.getClientId()));
+
+        MeetingPreAnalysisResponseDTO preAnalysis = meetingPreAnalysisRepository
+                .findByMeetingId(meeting.getId())
+                .map(MeetingPreAnalysisResponseDTO::from)
+                .orElse(null);
+
+        return new MeetingContextMetadataResponseDTO(
+                meeting.getId(),
+                meeting.getTitle(),
+                meeting.getStatus(),
+                meeting.getMeetingType(),
+                meeting.getObjective(),
+                meeting.getClientNeeds(),
+                meeting.getPreviousInteractions(),
+                meeting.getCompetitorsInvolved(),
+                meeting.getScheduledFor(),
+                meeting.getStartedAt(),
+                meeting.getEndedAt(),
+                meeting.getDurationSeconds(),
+                seller,
+                client,
+                preAnalysis,
+                meeting.getCreatedAt()
+        );
+    }
+}

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetMeetingContextAndMetadataUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetMeetingContextAndMetadataUseCase.java
@@ -7,7 +7,6 @@ import com.salespilot.api.application.dto.SellerMeetingResponseDTO;
 import com.salespilot.api.application.exception.ClientNotFoundException;
 import com.salespilot.api.application.exception.CollaboratorNotFoundException;
 import com.salespilot.api.application.exception.MeetingNotFoundException;
-import com.salespilot.api.domain.entity.Collaborator;
 import com.salespilot.api.domain.entity.Meeting;
 import com.salespilot.api.domain.repository.ClientRepository;
 import com.salespilot.api.domain.repository.CollaboratorRepository;

--- a/bootstrap/src/main/resources/data.sql
+++ b/bootstrap/src/main/resources/data.sql
@@ -30,3 +30,15 @@ INSERT INTO collaborators (id, company_id, name, email, role, active, preference
 ('d4e5f6a7-b8c9-0123-4567-890abcdef123', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'Laura Silva',    'laura@digitalsales.com',   'SELLER',       FALSE, '{}'),
 ('e5f6a7b8-c9d0-1234-5678-90abcdef1234', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'Saulo Souza',    'saulo@digitalsales.com',   'SELLER',       TRUE, '{"theme":"dark","default_model":"gpt-3.5"}')
 ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO clients (id, company_id, collaborator_id, name, client_company_name, sector, overall_sentiment, created_at, updated_at) VALUES
+('11111111-2222-3333-4444-555555555555', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'e5f6a7b8-c9d0-1234-5678-90abcdef1234', 'Marina Lima', 'Alfa Industrial', 'Manufacturing', 8, NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO meetings (id, collaborator_id, client_id, title, status, duration_seconds, objective, meeting_type, client_needs, previous_interactions, competitors_involved, scheduled_for, started_at, ended_at, created_at) VALUES
+('99999999-8888-7777-6666-555555555555', 'e5f6a7b8-c9d0-1234-5678-90abcdef1234', '11111111-2222-3333-4444-555555555555', 'Reuniao de descoberta', 'SCHEDULED', 1800, 'Entender dores e objetivos', 'ONLINE', 'Melhorar eficiencia', 'Contato inicial via email', 'Concorrente X', NOW(), NULL, NULL, NOW())
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO meeting_pre_analysis (id, meeting_id, recommended_strategy, key_points, possible_objections, created_at) VALUES
+('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', '99999999-8888-7777-6666-555555555555', '{"focus":"exploration"}'::jsonb, '["Entender processos atuais","Mapear stakeholders"]'::jsonb, '["Orcamento limitado","Prazo curto"]'::jsonb, NOW())
+ON CONFLICT (id) DO NOTHING;

--- a/docs/database.puml
+++ b/docs/database.puml
@@ -71,7 +71,7 @@ entity "meetings" as meetings {
   meeting_type : varchar
   client_needs : text 
   previous_interactions : text
-  competidors_involved : varchar
+  competitors_involved : varchar
   scheduled_for : datetime
   started_at : datetime
   ended_at : datetime
@@ -82,9 +82,9 @@ entity "meeting_pre_analysis" as pre_analysis {
   * id : uuid <<PK>>
   --
   meeting_id : uuid <<FK>>
-  recommended_strategy : json
-  key_points : json
-  possible_objections : json
+  recommended_strategy : jsonb
+  key_points : jsonb
+  possible_objections : jsonb
   created_at : datetime
 }
 

--- a/domain/src/main/java/com/salespilot/api/domain/entity/MeetingPreAnalysis.java
+++ b/domain/src/main/java/com/salespilot/api/domain/entity/MeetingPreAnalysis.java
@@ -3,6 +3,9 @@ package com.salespilot.api.domain.entity;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.salespilot.api.domain.valueobject.PreAnalysisKeyPoints;
+import com.salespilot.api.domain.valueobject.PreAnalysisPossibleObjections;
+import com.salespilot.api.domain.valueobject.PreAnalysisRecommendedStrategy;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,8 +14,8 @@ import lombok.Getter;
 public class MeetingPreAnalysis {
     private UUID id;
     private UUID meetingId;
-    private String recommendedStrategy;
-    private String keyPoints;
-    private String possibleObjections;
+    private PreAnalysisRecommendedStrategy recommendedStrategy;
+    private PreAnalysisKeyPoints keyPoints;
+    private PreAnalysisPossibleObjections possibleObjections;
     private LocalDateTime createdAt;
 }

--- a/domain/src/main/java/com/salespilot/api/domain/repository/MeetingPreAnalysisRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/MeetingPreAnalysisRepository.java
@@ -7,5 +7,4 @@ import java.util.UUID;
 
 public interface MeetingPreAnalysisRepository {
     Optional<MeetingPreAnalysis> findByMeetingId(UUID meetingId);
-    MeetingPreAnalysis save(MeetingPreAnalysis analysis);
 }

--- a/domain/src/main/java/com/salespilot/api/domain/repository/MeetingRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/MeetingRepository.java
@@ -4,10 +4,12 @@ import com.salespilot.api.domain.entity.Meeting;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface MeetingRepository {
     Page<Meeting> getAllMeetings(String title, String clientCompanyName, UUID collaboratorID, Pageable pageable);
     long getTotalMeetings();
     double getAverageDurationSeconds();
+    Optional<Meeting> getMeetingById(UUID id);
 }

--- a/domain/src/main/java/com/salespilot/api/domain/valueobject/PreAnalysisKeyPoints.java
+++ b/domain/src/main/java/com/salespilot/api/domain/valueobject/PreAnalysisKeyPoints.java
@@ -1,0 +1,13 @@
+package com.salespilot.api.domain.valueobject;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record PreAnalysisKeyPoints(
+        @JsonProperty("key_points")
+        List<String> keyPoints
+) {
+
+}

--- a/domain/src/main/java/com/salespilot/api/domain/valueobject/PreAnalysisPossibleObjections.java
+++ b/domain/src/main/java/com/salespilot/api/domain/valueobject/PreAnalysisPossibleObjections.java
@@ -1,0 +1,11 @@
+package com.salespilot.api.domain.valueobject;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record PreAnalysisPossibleObjections(
+        @JsonProperty("possible_objections")
+        List<String> possibleObjections
+) {
+}

--- a/domain/src/main/java/com/salespilot/api/domain/valueobject/PreAnalysisRecommendedStrategy.java
+++ b/domain/src/main/java/com/salespilot/api/domain/valueobject/PreAnalysisRecommendedStrategy.java
@@ -1,0 +1,6 @@
+package com.salespilot.api.domain.valueobject;
+
+public record PreAnalysisRecommendedStrategy(
+        String focus
+) {
+}

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
@@ -1,21 +1,8 @@
 package com.salespilot.api.infrastructure.config;
 
-import com.salespilot.api.application.usecase.GetAllCompaniesUseCase;
-import com.salespilot.api.application.usecase.GetCompanyByIdUseCase;
-import com.salespilot.api.application.usecase.GetSystemStatusUseCase;
-import com.salespilot.api.application.usecase.PostCompanyUseCase;
-import com.salespilot.api.application.usecase.UpdateCompanyUseCase;
-import com.salespilot.api.application.usecase.PostCollaboratorUseCase;
-import com.salespilot.api.application.usecase.EditCollaboratorUseCase;
-import com.salespilot.api.application.usecase.GetCollaboratorByIdUseCase;
-import com.salespilot.api.application.usecase.GetAllManagersUseCase;
-import com.salespilot.api.application.usecase.GetAllMeetingsUseCase;
+import com.salespilot.api.application.usecase.*;
 
-import com.salespilot.api.domain.repository.CollaboratorRepository;
-import com.salespilot.api.domain.repository.CompanyRepository;
-import com.salespilot.api.domain.repository.MeetingRepository;
-import com.salespilot.api.domain.repository.ClientRepository;
-import com.salespilot.api.domain.repository.SystemStatusRepository;
+import com.salespilot.api.domain.repository.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -70,5 +57,10 @@ public class UseCaseConfig {
     @Bean
     public GetAllMeetingsUseCase getAllMeetingsUseCase(MeetingRepository repository, ClientRepository clientRepository, CollaboratorRepository collaboratorRepository) {
         return new GetAllMeetingsUseCase(repository, clientRepository, collaboratorRepository);
+    }
+
+    @Bean
+    public GetMeetingContextAndMetadataUseCase getMeetingContextAndMetadataUseCase(MeetingRepository repository, CollaboratorRepository collaboratorRepository, ClientRepository clientRepository, MeetingPreAnalysisRepository meetingPreAnalysisRepository) {
+        return new GetMeetingContextAndMetadataUseCase(repository, collaboratorRepository, clientRepository, meetingPreAnalysisRepository);
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
@@ -1,8 +1,23 @@
 package com.salespilot.api.infrastructure.config;
 
-import com.salespilot.api.application.usecase.*;
+import com.salespilot.api.application.usecase.GetAllCompaniesUseCase;
+import com.salespilot.api.application.usecase.GetCompanyByIdUseCase;
+import com.salespilot.api.application.usecase.GetSystemStatusUseCase;
+import com.salespilot.api.application.usecase.PostCompanyUseCase;
+import com.salespilot.api.application.usecase.UpdateCompanyUseCase;
+import com.salespilot.api.application.usecase.PostCollaboratorUseCase;
+import com.salespilot.api.application.usecase.EditCollaboratorUseCase;
+import com.salespilot.api.application.usecase.GetCollaboratorByIdUseCase;
+import com.salespilot.api.application.usecase.GetAllManagersUseCase;
+import com.salespilot.api.application.usecase.GetAllMeetingsUseCase;
+import com.salespilot.api.application.usecase.GetMeetingContextAndMetadataUseCase;
 
-import com.salespilot.api.domain.repository.*;
+import com.salespilot.api.domain.repository.CollaboratorRepository;
+import com.salespilot.api.domain.repository.CompanyRepository;
+import com.salespilot.api.domain.repository.MeetingRepository;
+import com.salespilot.api.domain.repository.ClientRepository;
+import com.salespilot.api.domain.repository.SystemStatusRepository;
+import com.salespilot.api.domain.repository.MeetingPreAnalysisRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/entity/ClientEntity.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/entity/ClientEntity.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor
-public class Clients implements java.io.Serializable {
+public class ClientEntity implements java.io.Serializable {
 
     @Id
     @Column(name = "id", unique = true, nullable = false)
@@ -53,6 +53,6 @@ public class Clients implements java.io.Serializable {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "clients")
-    private Set<Meetings> meetings = new HashSet<>(0);
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "client")
+    private Set<MeetingEntity> meetings = new HashSet<>(0);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/entity/MeetingEntity.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/entity/MeetingEntity.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor
-public class Meetings implements java.io.Serializable {
+public class MeetingEntity implements java.io.Serializable {
 
     @Id
     @Column(name = "id", unique = true, nullable = false)
@@ -33,7 +33,7 @@ public class Meetings implements java.io.Serializable {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "client_id", nullable = false)
-    private Clients clients;
+    private ClientEntity client;
 
     @Column(name = "title")
     private String title;
@@ -71,12 +71,12 @@ public class Meetings implements java.io.Serializable {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "meetings")
-    private Set<MeetingPreAnalysis> meetingPreAnalyses = new HashSet<>(0);
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "meeting")
+    private Set<MeetingPreAnalysisEntity> meetingPreAnalyses = new HashSet<>(0);
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "meetings")
-    private Set<MeetingRealtimeInsights> meetingRealtimeInsights = new HashSet<>(0);
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "meeting")
+    private Set<MeetingRealtimeInsightsEntity> meetingRealtimeInsights = new HashSet<>(0);
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "meetings")
-    private Set<MeetingPostAnalysis> meetingPostAnalyses = new HashSet<>(0);
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "meeting")
+    private Set<MeetingPostAnalysisEntity> meetingPostAnalyses = new HashSet<>(0);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/entity/MeetingPostAnalysisEntity.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/entity/MeetingPostAnalysisEntity.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor
-public class MeetingPostAnalysis implements java.io.Serializable {
+public class MeetingPostAnalysisEntity implements java.io.Serializable {
 
     @Id
     @Column(name = "id", unique = true, nullable = false)
@@ -28,7 +28,7 @@ public class MeetingPostAnalysis implements java.io.Serializable {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_id", nullable = false)
-    private Meetings meetings;
+    private MeetingEntity meeting;
 
     @Column(name = "summary")
     private String summary;

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/entity/MeetingPreAnalysisEntity.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/entity/MeetingPreAnalysisEntity.java
@@ -1,5 +1,6 @@
 package com.salespilot.api.infrastructure.persistence.jpa.entity;
 
+import com.salespilot.api.domain.valueobject.PreAnalysisRecommendedStrategy;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -13,6 +14,7 @@ import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -20,7 +22,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor
-public class MeetingPreAnalysis implements java.io.Serializable {
+public class MeetingPreAnalysisEntity implements java.io.Serializable {
 
     @Id
     @Column(name = "id", unique = true, nullable = false)
@@ -28,19 +30,19 @@ public class MeetingPreAnalysis implements java.io.Serializable {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_id", nullable = false)
-    private Meetings meetings;
+    private MeetingEntity meeting;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "recommended_strategy", columnDefinition = "json")
-    private String recommendedStrategy;
+    @Column(name = "recommended_strategy", columnDefinition = "jsonb")
+    private PreAnalysisRecommendedStrategy preAnalysisRecommendedStrategy;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "key_points", columnDefinition = "json")
-    private String keyPoints;
+    @Column(name = "key_points", columnDefinition = "jsonb")
+    private List<String> preAnalysisKeyPoints;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "possible_objections", columnDefinition = "json")
-    private String possibleObjections;
+    @Column(name = "possible_objections", columnDefinition = "jsonb")
+    private List<String> preAnalysisPossibleObjections;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/entity/MeetingRealtimeInsightsEntity.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/entity/MeetingRealtimeInsightsEntity.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor
-public class MeetingRealtimeInsights implements java.io.Serializable {
+public class MeetingRealtimeInsightsEntity implements java.io.Serializable {
 
     @Id
     @Column(name = "id", unique = true, nullable = false)
@@ -30,7 +30,7 @@ public class MeetingRealtimeInsights implements java.io.Serializable {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_id", nullable = false)
-    private Meetings meetings;
+    private MeetingEntity meeting;
 
     @Column(name = "content", nullable = false)
     private String content;

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/mapper/ClientMapper.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/mapper/ClientMapper.java
@@ -1,22 +1,22 @@
 package com.salespilot.api.infrastructure.persistence.jpa.mapper;
 
 import com.salespilot.api.domain.entity.Client;
-import com.salespilot.api.infrastructure.persistence.jpa.entity.Clients;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.ClientEntity;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ClientMapper {
-    public Client toDomain(Clients clients) {
+    public Client toDomain(ClientEntity clientEntity) {
         return new Client(
-                clients.getId(),
-                clients.getCompany().getId(),
-                clients.getCollaborator().getId(),
-                clients.getName(),
-                clients.getClientCompanyName(),
-                clients.getSector(),
-                clients.getOverallSentiment(),
-                clients.getCreatedAt(),
-                clients.getUpdatedAt()
+                clientEntity.getId(),
+                clientEntity.getCompany().getId(),
+                clientEntity.getCollaborator().getId(),
+                clientEntity.getName(),
+                clientEntity.getClientCompanyName(),
+                clientEntity.getSector(),
+                clientEntity.getOverallSentiment(),
+                clientEntity.getCreatedAt(),
+                clientEntity.getUpdatedAt()
         );
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/mapper/MeetingMapper.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/mapper/MeetingMapper.java
@@ -1,28 +1,28 @@
 package com.salespilot.api.infrastructure.persistence.jpa.mapper;
 
 import com.salespilot.api.domain.entity.Meeting;
-import com.salespilot.api.infrastructure.persistence.jpa.entity.Meetings;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingEntity;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MeetingMapper {
-    public Meeting toDomain(Meetings meetings) {
+    public Meeting toDomain(MeetingEntity meetingEntity) {
         return new Meeting(
-                meetings.getId(),
-                meetings.getCollaborator().getId(),
-                meetings.getClients().getId(),
-                meetings.getTitle(),
-                meetings.getStatus(),
-                meetings.getDurationSeconds(),
-                meetings.getObjective(),
-                meetings.getMeetingType(),
-                meetings.getClientNeeds(),
-                meetings.getPreviousInteractions(),
-                meetings.getCompetitorsInvolved(),
-                meetings.getScheduledFor(),
-                meetings.getStartedAt(),
-                meetings.getEndedAt(),
-                meetings.getCreatedAt()
+                meetingEntity.getId(),
+                meetingEntity.getCollaborator().getId(),
+                meetingEntity.getClient().getId(),
+                meetingEntity.getTitle(),
+                meetingEntity.getStatus(),
+                meetingEntity.getDurationSeconds(),
+                meetingEntity.getObjective(),
+                meetingEntity.getMeetingType(),
+                meetingEntity.getClientNeeds(),
+                meetingEntity.getPreviousInteractions(),
+                meetingEntity.getCompetitorsInvolved(),
+                meetingEntity.getScheduledFor(),
+                meetingEntity.getStartedAt(),
+                meetingEntity.getEndedAt(),
+                meetingEntity.getCreatedAt()
         );
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/mapper/MeetingPreAnalysisMapper.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/mapper/MeetingPreAnalysisMapper.java
@@ -1,0 +1,21 @@
+package com.salespilot.api.infrastructure.persistence.jpa.mapper;
+
+import com.salespilot.api.domain.entity.MeetingPreAnalysis;
+import com.salespilot.api.domain.valueobject.PreAnalysisKeyPoints;
+import com.salespilot.api.domain.valueobject.PreAnalysisPossibleObjections;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingPreAnalysisEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MeetingPreAnalysisMapper {
+    public MeetingPreAnalysis toDomain(MeetingPreAnalysisEntity entity) {
+        return new MeetingPreAnalysis(
+                entity.getId(),
+                entity.getMeeting().getId(),
+                entity.getPreAnalysisRecommendedStrategy(),
+                new PreAnalysisKeyPoints(entity.getPreAnalysisKeyPoints()),
+                new PreAnalysisPossibleObjections(entity.getPreAnalysisPossibleObjections()),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/ClientsJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/ClientsJpaRepository.java
@@ -1,9 +1,9 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
-import com.salespilot.api.infrastructure.persistence.jpa.entity.Clients;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.ClientEntity;
 
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ClientsJpaRepository extends JpaRepository<Clients, UUID> {
+public interface ClientsJpaRepository extends JpaRepository<ClientEntity, UUID> {
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisJpaRepository.java
@@ -1,8 +1,8 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
-import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingPostAnalysis;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingPostAnalysisEntity;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MeetingPostAnalysisJpaRepository extends JpaRepository<MeetingPostAnalysis, UUID> {
+public interface MeetingPostAnalysisJpaRepository extends JpaRepository<MeetingPostAnalysisEntity, UUID> {
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPreAnalysisJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPreAnalysisJpaRepository.java
@@ -1,8 +1,11 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
-import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingPreAnalysis;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingPreAnalysisEntity;
+
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MeetingPreAnalysisJpaRepository extends JpaRepository<MeetingPreAnalysis, UUID> {
+public interface MeetingPreAnalysisJpaRepository extends JpaRepository<MeetingPreAnalysisEntity, UUID> {
+    Optional<MeetingPreAnalysisEntity> findByMeetingId(UUID meetingId);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPreAnalysisRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPreAnalysisRepositoryImpl.java
@@ -10,8 +10,8 @@ import java.util.UUID;
 
 @Repository
 public class MeetingPreAnalysisRepositoryImpl implements MeetingPreAnalysisRepository {
-    private MeetingPreAnalysisJpaRepository meetingPreAnalysisJpaRepository;
-    private MeetingPreAnalysisMapper mapper;
+    private final MeetingPreAnalysisJpaRepository meetingPreAnalysisJpaRepository;
+    private final MeetingPreAnalysisMapper mapper;
 
     public MeetingPreAnalysisRepositoryImpl(MeetingPreAnalysisJpaRepository meetingPreAnalysisJpaRepository, MeetingPreAnalysisMapper mapper) {
         this.meetingPreAnalysisJpaRepository = meetingPreAnalysisJpaRepository;

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPreAnalysisRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPreAnalysisRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.salespilot.api.infrastructure.persistence.jpa.repository;
+
+import com.salespilot.api.domain.entity.MeetingPreAnalysis;
+import com.salespilot.api.domain.repository.MeetingPreAnalysisRepository;
+import com.salespilot.api.infrastructure.persistence.jpa.mapper.MeetingPreAnalysisMapper;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class MeetingPreAnalysisRepositoryImpl implements MeetingPreAnalysisRepository {
+    private MeetingPreAnalysisJpaRepository meetingPreAnalysisJpaRepository;
+    private MeetingPreAnalysisMapper mapper;
+
+    public MeetingPreAnalysisRepositoryImpl(MeetingPreAnalysisJpaRepository meetingPreAnalysisJpaRepository, MeetingPreAnalysisMapper mapper) {
+        this.meetingPreAnalysisJpaRepository = meetingPreAnalysisJpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Optional<MeetingPreAnalysis> findByMeetingId(UUID meetingId) {
+        return meetingPreAnalysisJpaRepository.findByMeetingId(meetingId)
+                .map(mapper::toDomain);
+    }
+}

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRealtimeInsightsJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRealtimeInsightsJpaRepository.java
@@ -1,8 +1,8 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
-import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingRealtimeInsights;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingRealtimeInsightsEntity;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MeetingRealtimeInsightsJpaRepository extends JpaRepository<MeetingRealtimeInsights, UUID> {
+public interface MeetingRealtimeInsightsJpaRepository extends JpaRepository<MeetingRealtimeInsightsEntity, UUID> {
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
 import com.salespilot.api.domain.entity.Meeting;
 import com.salespilot.api.domain.repository.MeetingRepository;
-import com.salespilot.api.infrastructure.persistence.jpa.entity.Meetings;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingEntity;
 import com.salespilot.api.infrastructure.persistence.jpa.mapper.MeetingMapper;
 import com.salespilot.api.infrastructure.persistence.jpa.specification.MeetingSpecification;
 import org.springframework.data.domain.Page;
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -26,7 +27,7 @@ public class MeetingRepositoryImpl implements MeetingRepository {
     @Transactional(readOnly = true)
     @Override
     public Page<Meeting> getAllMeetings(String title, String clientCompanyName, UUID collaboratorID, Pageable pageable) {
-        Specification<Meetings> spec = Specification
+        Specification<MeetingEntity> spec = Specification
                 .where(MeetingSpecification.titleLike(title)
                 .and(MeetingSpecification.clientCompanyNameLike(clientCompanyName)
                 .and(MeetingSpecification.collaboratorIdEquals(collaboratorID)))
@@ -41,5 +42,10 @@ public class MeetingRepositoryImpl implements MeetingRepository {
 
     public double getAverageDurationSeconds() {
         return meetingsJpaRepository.findAverageDurationSeconds().orElse(0.0);
+    }
+
+    @Override
+    public Optional<Meeting> getMeetingById(UUID id) {
+        return meetingsJpaRepository.findById(id).map(mapper::toDomain);
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingsJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingsJpaRepository.java
@@ -1,6 +1,6 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
-import com.salespilot.api.infrastructure.persistence.jpa.entity.Meetings;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingEntity;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
-public interface MeetingsJpaRepository extends JpaRepository<Meetings, UUID>, JpaSpecificationExecutor<Meetings> {
-    @Query("SELECT AVG(m.durationSeconds) FROM Meetings m WHERE m.durationSeconds IS NOT NULL")
+public interface MeetingsJpaRepository extends JpaRepository<MeetingEntity, UUID>, JpaSpecificationExecutor<MeetingEntity> {
+    @Query("SELECT AVG(m.durationSeconds) FROM MeetingEntity m WHERE m.durationSeconds IS NOT NULL")
     Optional<Double> findAverageDurationSeconds();
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/specification/MeetingSpecification.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/specification/MeetingSpecification.java
@@ -1,28 +1,28 @@
 package com.salespilot.api.infrastructure.persistence.jpa.specification;
 
-import com.salespilot.api.infrastructure.persistence.jpa.entity.Meetings;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingEntity;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.util.UUID;
 
 public class MeetingSpecification {
 
-    public static Specification<Meetings> titleLike(String title) {
+    public static Specification<MeetingEntity> titleLike(String title) {
         return (root, query, cb) -> title == null || title.isBlank() ? null
                 : cb.like(cb.lower(root.get("title")), "%" + title.toLowerCase() + "%");
     }
 
-    public static Specification<Meetings> clientCompanyNameLike(String clientCompanyName) {
+    public static Specification<MeetingEntity> clientCompanyNameLike(String clientCompanyName) {
         return (root, query, cb) -> clientCompanyName == null || clientCompanyName.isBlank() ? null
-                : cb.like(cb.lower(root.join("clients").get("clientCompanyName")), "%" + clientCompanyName.toLowerCase() + "%");
+                : cb.like(cb.lower(root.join("client").get("clientCompanyName")), "%" + clientCompanyName.toLowerCase() + "%");
     }
 
-    public static Specification<Meetings> collaboratorIdEquals(UUID collaboratorId) {
+    public static Specification<MeetingEntity> collaboratorIdEquals(UUID collaboratorId) {
         return (root, query, cb) -> collaboratorId == null ? null
                 : cb.equal(root.get("collaborator").get("id"), collaboratorId);
     }
 
-    public static Specification<Meetings> collaboratorIsActive(UUID collaboratorId) {
+    public static Specification<MeetingEntity> collaboratorIsActive(UUID collaboratorId) {
         return (root, query, cb) -> collaboratorId == null ? null
                 : cb.equal(root.get("collaborator").get("active"), true);
     }

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
@@ -8,7 +8,11 @@ import com.salespilot.api.presentation.utils.PageableUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.UUID;
 

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
@@ -1,15 +1,14 @@
 package com.salespilot.api.presentation.controller;
 
+import com.salespilot.api.application.dto.MeetingContextMetadataResponseDTO;
 import com.salespilot.api.application.dto.MeetingPageResponseDTO;
 import com.salespilot.api.application.usecase.GetAllMeetingsUseCase;
+import com.salespilot.api.application.usecase.GetMeetingContextAndMetadataUseCase;
 import com.salespilot.api.presentation.utils.PageableUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -18,10 +17,11 @@ import java.util.UUID;
 @RequestMapping("/api/meetings")
 public class MeetingController {
     private final GetAllMeetingsUseCase getAllMeetingsUseCase;
+    private final GetMeetingContextAndMetadataUseCase getMeetingContextAndMetadataUseCase;
 
-
-    public MeetingController(GetAllMeetingsUseCase getAllMeetingsUseCase) {
+    public MeetingController(GetAllMeetingsUseCase getAllMeetingsUseCase, GetMeetingContextAndMetadataUseCase getMeetingContextAndMetadataUseCase) {
         this.getAllMeetingsUseCase = getAllMeetingsUseCase;
+        this.getMeetingContextAndMetadataUseCase = getMeetingContextAndMetadataUseCase;
     }
 
     @GetMapping
@@ -32,5 +32,10 @@ public class MeetingController {
             Pageable pageable) {
 
         return ResponseEntity.ok(getAllMeetingsUseCase.execute(title, clientCompanyName, collaboratorId, PageableUtils.normalize(pageable)));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<MeetingContextMetadataResponseDTO> getMeetingContextAndMetadata(@PathVariable UUID id) {
+        return ResponseEntity.ok(getMeetingContextAndMetadataUseCase.execute(id));
     }
 }


### PR DESCRIPTION
## Issue relacionada

https://github.com/SalesPilot-AGES/Backend/issues/11

## O que foi implementado?

Foi implementada a funcionalidade de pegar o contexto e metadados de uma reunião a partir do seu id.

## Por que essa mudança é necessária?

É uma das funções esperadas para a Sprint 2 e é fundamental para a aplicação.

## Como testar?

Acessar o endpoint (utilizando GET): 

locahost:8080/api/meetings/{id} 

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças

<img width="1097" height="940" alt="image" src="https://github.com/user-attachments/assets/b4cda0c0-f0d3-48b2-921d-9cfdb709f9d0" />