### PR TITLE
docs: add swagger docs to meeting endpoints

### DIFF
--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
@@ -39,18 +39,110 @@ public class MeetingController {
         this.getMeetingPostAnalysisUseCase = getMeetingPostAnalysisUseCase;
     }
 
+    @Operation(summary = "Listar reuniões", description = "Retorna uma página de reuniões com filtros opcionais e métricas gerais.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Reuniões retornadas com sucesso",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = MeetingPageResponseDTO.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "content": [
+                                            {
+                                                "id": "99999999-8888-7777-6666-555555555555",
+                                                "title": "Reuniao de descoberta",
+                                                "seller": {
+                                                    "id": "e5f6a7b8-c9d0-1234-5678-90abcdef1234",
+                                                    "name": "Saulo Souza",
+                                                    "email": "saulo@digitalsales.com"
+                                                },
+                                                "client": {
+                                                    "id": "11111111-2222-3333-4444-555555555555",
+                                                    "name": "Marina Lima",
+                                                    "client_company_name": "Alfa Industrial",
+                                                    "sector": "Manufacturing",
+                                                    "overall_sentiment": 8
+                                                },
+                                                "meeting_type": "ONLINE",
+                                                "scheduled_for": "2026-05-02T15:50:24.533071",
+                                                "started_at": null,
+                                                "ended_at": null,
+                                                "duration_seconds": 1800,
+                                                "status": "SCHEDULED"
+                                            }
+                                        ],
+                                        "total_elements": 1,
+                                        "total_pages": 1,
+                                        "summary": {
+                                            "total_meetings": 1,
+                                            "average_duration_seconds": 1800.0,
+                                            "success_rate": 0.0
+                                        }
+                                    }
+                                    """)))
+    })
     @GetMapping
     public ResponseEntity<MeetingPageResponseDTO> getAllMeetings(
-            @RequestParam(required = false) String title,
-            @RequestParam(required = false) String clientCompanyName,
-            @RequestParam(required = false) UUID collaboratorId,
+            @Parameter(description = "Filtrar por título (parcial)") @RequestParam(required = false) String title,
+            @Parameter(description = "Filtrar por empresa do cliente (parcial)") @RequestParam(required = false) String clientCompanyName,
+            @Parameter(description = "Filtrar por ID do vendedor") @RequestParam(required = false) UUID collaboratorId,
             Pageable pageable) {
-
         return ResponseEntity.ok(getAllMeetingsUseCase.execute(title, clientCompanyName, collaboratorId, PageableUtils.normalize(pageable)));
     }
 
+    @Operation(summary = "Buscar reunião por ID", description = "Retorna os dados completos de contexto e metadados de uma reunião.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Reunião encontrada",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = MeetingContextMetadataResponseDTO.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "id": "m1a2b3c4-d5e6-7890-1234-56789abcdef0",
+                                      "title": "Reuniao de prospeccao",
+                                      "status": "completed",
+                                      "meeting_type": "online",
+                                      "objective": "Apresentar proposta comercial",
+                                      "client_needs": "Integracao com CRM e previsibilidade de pipeline",
+                                      "previous_interactions": "Demo realizada em 2024-05-20",
+                                      "competitors_involved": "Concorrente X",
+                                      "scheduled_for": "2024-06-10T14:00:00Z",
+                                      "started_at": "2024-06-10T14:03:00Z",
+                                      "ended_at": "2024-06-10T14:45:00Z",
+                                      "duration_seconds": 2520,
+                                      "seller": {
+                                        "id": "b2c3d4e5-f6a7-8901-2345-67890abcdef1",
+                                        "name": "Ana Silva Vendedora",
+                                        "email": "ana.silva@tech.com.br"
+                                      },
+                                      "client": {
+                                        "id": "c1a2b3c4-d5e6-7890-1234-56789abcdef0",
+                                        "name": "Carlos Lima",
+                                        "client_company_name": "Tech Solutions Ltda",
+                                        "sector": "Tecnologia",
+                                        "overall_sentiment": 79
+                                      },
+                                      "pre_analysis": {
+                                        "id": "p1a2b3c4-d5e6-7890-1234-56789abcdef0",
+                                        "recommended_strategy": {
+                                          "focus": "ROI e tempo de implementacao"
+                                        },
+                                        "key_points": [
+                                          "Mapear processo atual",
+                                          "Explorar gargalos comerciais"
+                                        ],
+                                        "possible_objections": [
+                                          "Preco",
+                                          "Prazo de rollout"
+                                        ],
+                                        "created_at": "2024-06-10T13:40:00Z"
+                                      },
+                                      "created_at": "2024-06-10T13:30:00Z"
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "Reunião, seller ou cliente não encontrado", content = @Content)
+    })
     @GetMapping("/{id}")
-    public ResponseEntity<MeetingContextMetadataResponseDTO> getMeetingContextAndMetadata(@PathVariable UUID id) {
+    public ResponseEntity<MeetingContextMetadataResponseDTO> getMeetingContextAndMetadata(
+            @Parameter(description = "UUID da reunião") @PathVariable UUID id) {
         return ResponseEntity.ok(getMeetingContextAndMetadataUseCase.execute(id));
     }
 
@@ -83,6 +175,7 @@ public class MeetingController {
                                     """))),
             @ApiResponse(responseCode = "404", description = "Pós-análise da reunião não encontrada", content = @Content)
     })
+
     @GetMapping("/{id}/post-analysis")
     public ResponseEntity<MeetingPostAnalysisResponseDTO> getMeetingPostAnalysis(
             @Parameter(description = "UUID da reunião") @PathVariable UUID id) {

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
@@ -98,8 +98,8 @@ public class MeetingController {
                                     {
                                       "id": "m1a2b3c4-d5e6-7890-1234-56789abcdef0",
                                       "title": "Reuniao de prospeccao",
-                                      "status": "completed",
-                                      "meeting_type": "online",
+                                      "status": "COMPLETED",
+                                      "meeting_type": "ONLINE",
                                       "objective": "Apresentar proposta comercial",
                                       "client_needs": "Integracao com CRM e previsibilidade de pipeline",
                                       "previous_interactions": "Demo realizada em 2024-05-20",


### PR DESCRIPTION
## Issue relacionada

https://github.com/SalesPilot-AGES/Backend/issues/10 e https://github.com/SalesPilot-AGES/Backend/issues/11

## O que foi implementado?

Apenas a documentação do swagger que estava faltando nas branches originais das tasks acima.

## Por que essa mudança é necessária?

A documentação facilita o entendimento e teste dos endpoints, além de manter o Swagger atualizado com as features implementadas.

## Como testar?

Ao rodar o projeto, acessar o link:

http://localhost:8080/swagger-ui/index.html#/

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças

<img width="1818" height="202" alt="image" src="https://github.com/user-attachments/assets/914f694d-7a22-487a-b8d7-e54ecf248efb" />
