### PR TITLE
fix: make phone and preferences optional on collaborator update

### DIFF
--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/CollaboratorController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/CollaboratorController.java
@@ -11,6 +11,7 @@ import com.salespilot.api.application.usecase.GetSellerByIdUseCase;
 import com.salespilot.api.application.usecase.PostCollaboratorUseCase;
 import com.salespilot.api.domain.enums.CollaboratorRole;
 import com.salespilot.api.presentation.dto.CollaboratorRequestDTO;
+import com.salespilot.api.presentation.dto.CollaboratorUpdateRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -154,7 +155,7 @@ public class CollaboratorController {
     }
 
     @Operation(summary = "Editar manager", description = "Atualiza os dados de um colaborador com papel de MANAGER.")
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorUpdateRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Manager atualizado com sucesso", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = MANAGER_RESPONSE_EXAMPLE))),
             @ApiResponse(responseCode = "404", description = "Manager não encontrado", content = @Content),
@@ -166,7 +167,7 @@ public class CollaboratorController {
     @PutMapping("/managers/{id}")
     public ResponseEntity<CollaboratorResponseDTO> editCollaborator(
             @Parameter(description = "UUID do manager") @PathVariable UUID id,
-            @Valid @RequestBody CollaboratorRequestDTO request) {
+            @Valid @RequestBody CollaboratorUpdateRequestDTO request) {
         CollaboratorResponseDTO response = editCollaboratorUseCase.execute(
                 request.companyId(),
                 id,
@@ -245,7 +246,7 @@ public class CollaboratorController {
     }
     
     @Operation(summary = "Editar seller", description = "Atualiza os dados de um colaborador com papel de SELLER.")
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorUpdateRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Seller atualizado com sucesso", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = SELLER_RESPONSE_EXAMPLE))),
             @ApiResponse(responseCode = "404", description = "Seller não encontrado", content = @Content),
@@ -255,7 +256,7 @@ public class CollaboratorController {
     @PutMapping("/sellers/{id}")
     public ResponseEntity<CollaboratorResponseDTO> editSeller(
             @Parameter(description = "UUID do seller") @PathVariable UUID id,
-            @Valid @RequestBody CollaboratorRequestDTO request) {
+            @Valid @RequestBody CollaboratorUpdateRequestDTO request) {
         CollaboratorResponseDTO response = editCollaboratorUseCase.execute(
                 request.companyId(),
                 id,

--- a/presentation/src/main/java/com/salespilot/api/presentation/dto/CollaboratorRequestDTO.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/dto/CollaboratorRequestDTO.java
@@ -24,7 +24,7 @@ public record CollaboratorRequestDTO(
         boolean active,
 
         @Schema(description = "Telefone do colaborador", example = "+55 (11) 98888-7777")
-        @NotBlank String phone,
+        String phone,
 
         @Schema(description = "Preferências de interface do colaborador")
         @Valid @NotNull CollaboratorPreferences preferences

--- a/presentation/src/main/java/com/salespilot/api/presentation/dto/CollaboratorRequestDTO.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/dto/CollaboratorRequestDTO.java
@@ -2,7 +2,6 @@ package com.salespilot.api.presentation.dto;
 
 import com.salespilot.api.domain.valueobject.CollaboratorPreferences;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -27,5 +26,5 @@ public record CollaboratorRequestDTO(
         String phone,
 
         @Schema(description = "Preferências de interface do colaborador")
-        @Valid @NotNull CollaboratorPreferences preferences
+        CollaboratorPreferences preferences
 ) {}

--- a/presentation/src/main/java/com/salespilot/api/presentation/dto/CollaboratorUpdateRequestDTO.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/dto/CollaboratorUpdateRequestDTO.java
@@ -1,0 +1,30 @@
+package com.salespilot.api.presentation.dto;
+
+import com.salespilot.api.domain.valueobject.CollaboratorPreferences;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+@Schema(description = "Dados para atualização de um colaborador")
+public record CollaboratorUpdateRequestDTO(
+        @Schema(description = "UUID da empresa à qual o colaborador pertence", example = "b1c2d3e4-f5a6-7890-2345-67890abcdef1")
+        @NotNull UUID companyId,
+
+        @Schema(description = "Nome completo do colaborador", example = "Gabriel Ribeiro")
+        @NotBlank String name,
+
+        @Schema(description = "E-mail do colaborador", example = "gabriel@digitalsales.com")
+        @Email @NotBlank String email,
+
+        @Schema(description = "Se o colaborador está ativo", example = "true")
+        boolean active,
+
+        @Schema(description = "Telefone do colaborador", example = "+55 (11) 98888-7777")
+        String phone,
+
+        @Schema(description = "Preferências de interface do colaborador")
+        CollaboratorPreferences preferences
+) {}


### PR DESCRIPTION
## Issue relacionada

N/A

## O que foi implementado?

-  Removida a obrigatoriedade do campo phone no CollaboratorRequestDTO (criação de seller e manager)                                                                                                                               
  - Criado CollaboratorUpdateRequestDTO com os campos phone e preferences opcionais
  - Endpoints de edição de seller (PUT /sellers/{id}) e manager (PUT /managers/{id}) passaram a usar o novo DTO    
## Por que essa mudança é necessária?

Ao criar ou editar um colaborador, os campos phone e preferences estavam marcados como obrigatórios mesmo quando não há necessidade de fornecê-los. Na criação, o telefone pode ser desconhecido. Na edição, o cliente pode querer
   atualizar apenas nome ou e-mail sem precisar reenviar todos os campos. DTOs separados para criação e atualização permitem regras de validação independentes para cada operação.

## Como testar?

 1. POST /sellers ou POST /managers sem o campo phone — deve retornar 201
  2. PUT /sellers/{id} ou PUT /managers/{id} sem os campos phone e preferences — deve retornar 200                                                                                                                                
  3. POST /sellers ou POST /managers sem o campo preferences — deve retornar 422 (ainda obrigatório na criação)   

## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças