### PR TITLE
fix: sentiment analysis

### DIFF
--- a/application/src/main/java/com/salespilot/api/application/dto/SellerResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/SellerResponseDTO.java
@@ -14,7 +14,7 @@ public record SellerResponseDTO(
         String email,
         String phone,
         boolean active,
-        Integer averageFeeling,
+        Double averageFeeling,
         Long totalMeetings,
         CollaboratorPreferences preferences,
         LocalDateTime createdAt,

--- a/application/src/main/java/com/salespilot/api/application/dto/SummaryResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/SummaryResponseDTO.java
@@ -3,5 +3,5 @@ package com.salespilot.api.application.dto;
 public record SummaryResponseDTO(
         long totalMeetings,
         double averageDurationSeconds,
-        double successRate
+        Double successRate
 ) {}

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetAllMeetingsUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetAllMeetingsUseCase.java
@@ -6,6 +6,7 @@ import com.salespilot.api.application.exception.CollaboratorNotFoundException;
 import com.salespilot.api.domain.entity.Collaborator;
 import com.salespilot.api.domain.repository.ClientRepository;
 import com.salespilot.api.domain.repository.CollaboratorRepository;
+import com.salespilot.api.domain.repository.MeetingPostAnalysisRepository;
 import com.salespilot.api.domain.repository.MeetingRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,12 +15,13 @@ import java.util.UUID;
 
 public class GetAllMeetingsUseCase {
     private final MeetingRepository repository;
+    private final MeetingPostAnalysisRepository meetingPostAnalysisRepository;
     private final ClientRepository clientRepository;
     private final CollaboratorRepository collaboratorRepository;
-    private final int TEMPORARY_DEFAULT_SUCCESS_RATE = 0;
 
-    public GetAllMeetingsUseCase(MeetingRepository meetingRepository, ClientRepository clientRepository, CollaboratorRepository collaboratorRepository) {
+    public GetAllMeetingsUseCase(MeetingRepository meetingRepository, MeetingPostAnalysisRepository meetingPostAnalysisRepository, ClientRepository clientRepository, CollaboratorRepository collaboratorRepository) {
         this.repository = meetingRepository;
+        this.meetingPostAnalysisRepository = meetingPostAnalysisRepository;
         this.clientRepository = clientRepository;
         this.collaboratorRepository = collaboratorRepository;
     }
@@ -53,7 +55,7 @@ public class GetAllMeetingsUseCase {
         return MeetingPageResponseDTO.from(page, new SummaryResponseDTO(
                 repository.getTotalMeetings(),
                 repository.getAverageDurationSeconds(),
-                TEMPORARY_DEFAULT_SUCCESS_RATE
+                meetingPostAnalysisRepository.getAverageSuccessRate()
         ));
     }
 }

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetAllSellersUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetAllSellersUseCase.java
@@ -5,6 +5,7 @@ import com.salespilot.api.application.dto.SellerResponseDTO;
 import com.salespilot.api.application.exception.CompanyNotFoundException;
 import com.salespilot.api.domain.repository.CollaboratorRepository;
 import com.salespilot.api.domain.repository.CompanyRepository;
+import com.salespilot.api.domain.repository.MeetingPostAnalysisRepository;
 import com.salespilot.api.domain.repository.MeetingRepository;
 
 import org.springframework.data.domain.Page;
@@ -17,11 +18,13 @@ public class GetAllSellersUseCase {
     private final CollaboratorRepository repository;
     private final CompanyRepository companyRepository;
     private final MeetingRepository meetingRepository;
+    private final MeetingPostAnalysisRepository meetingPostAnalysisRepository;
 
-    public GetAllSellersUseCase(CollaboratorRepository repository, CompanyRepository companyRepository, MeetingRepository meetingRepository) {
+    public GetAllSellersUseCase(CollaboratorRepository repository, CompanyRepository companyRepository, MeetingRepository meetingRepository, MeetingPostAnalysisRepository meetingPostAnalysisRepository) {
         this.repository = repository;
         this.companyRepository = companyRepository;
         this.meetingRepository = meetingRepository;
+        this.meetingPostAnalysisRepository = meetingPostAnalysisRepository;
     }
 
     public Page<SellerResponseDTO> execute(String name, String email, UUID companyId, Boolean active, Pageable pageable) {
@@ -29,6 +32,7 @@ public class GetAllSellersUseCase {
         return repository.getSellers(name, email, companyId, active, pageable)
                 .map(c -> {
                     Long totalMeetings = meetingRepository.getTotalMeetingsByCollaborator(c.getId());
+                    Double averageFeeling = meetingPostAnalysisRepository.getAverageFeelingByCollaborator(c.getId());
                     return new SellerResponseDTO(
                         c.getId(),
                         c.getCompanyId(),
@@ -37,7 +41,7 @@ public class GetAllSellersUseCase {
                         c.getEmail(),
                         c.getPhone(),
                         c.isActive(),
-                        c.getAverageFeeling(),
+                        averageFeeling,
                         totalMeetings,
                         c.getPreferences(),
                         c.getCreatedAt(),

--- a/bootstrap/src/main/resources/data.sql
+++ b/bootstrap/src/main/resources/data.sql
@@ -27,22 +27,80 @@ ON CONFLICT (id) DO NOTHING;
 INSERT INTO collaborators (id, company_id, name, email, role, active, preferences) VALUES
 ('b2c3d4e5-f6a7-8901-2345-67890abcdef1', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'Ana Costa',      'ana@digitalsales.com',     'SYSTEM_ADMIN', TRUE, '{"theme":"dark","default_model":"gpt-4o"}'),
 ('c3d4e5f6-a7b8-9012-3456-7890abcdef12', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'Gabriel Ribeiro', 'gabriel@digitalsales.com', 'MANAGER',      TRUE, '{"theme":"light","default_model":"gpt-4o"}'),
-('d4e5f6a7-b8c9-0123-4567-890abcdef123', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'Laura Silva',    'laura@digitalsales.com',   'SELLER',       FALSE, '{}'),
-('e5f6a7b8-c9d0-1234-5678-90abcdef1234', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'Saulo Souza',    'saulo@digitalsales.com',   'SELLER',       TRUE, '{"theme":"dark","default_model":"gpt-3.5"}')
+('d4e5f6a7-b8c9-0123-4567-890abcdef123', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'Laura Silva',    'laura@digitalsales.com',    'SELLER', FALSE, '{}'),
+('e5f6a7b8-c9d0-1234-5678-90abcdef1234', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'Saulo Souza',    'saulo@digitalsales.com',    'SELLER', TRUE,  '{"theme":"dark","default_model":"gpt-3.5"}'),
+('f6a7b8c9-d0e1-2345-6789-0abcdef12345', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'Marcos Pereira', 'marcos@digitalsales.com',   'SELLER', TRUE,  '{"theme":"light","default_model":"gpt-4o"}'),
+('a7b8c9d0-e1f2-3456-7890-abcdef123456', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'Julia Fernandes','julia@digitalsales.com',    'SELLER', TRUE,  '{"theme":"dark","default_model":"gpt-4o"}')
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO clients (id, company_id, collaborator_id, name, client_company_name, sector, overall_sentiment, created_at, updated_at) VALUES
-('11111111-2222-3333-4444-555555555555', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'e5f6a7b8-c9d0-1234-5678-90abcdef1234', 'Marina Lima', 'Alfa Industrial', 'Manufacturing', 8, NOW(), NOW())
+('11111111-2222-3333-4444-555555555555', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'e5f6a7b8-c9d0-1234-5678-90abcdef1234', 'Marina Lima',     'Alfa Industrial',  'Manufacturing', 8,  NOW(), NOW()),
+('21111111-2222-3333-4444-555555555555', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'f6a7b8c9-d0e1-2345-6789-0abcdef12345', 'Carlos Mendes',   'BetaTech',         'Technology',    7,  NOW(), NOW()),
+('31111111-2222-3333-4444-555555555555', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'e5f6a7b8-c9d0-1234-5678-90abcdef1234', 'Patricia Rocha',  'Nexus Logística',  'Logistics',     6,  NOW(), NOW()),
+('41111111-2222-3333-4444-555555555555', 'b1c2d3e4-f5a6-7890-2345-67890abcdef1', 'a7b8c9d0-e1f2-3456-7890-abcdef123456', 'Roberto Campos',  'Sigma Varejo',     'Retail',        5,  NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO meetings (id, collaborator_id, client_id, title, status, duration_seconds, objective, meeting_type, client_needs, previous_interactions, competitors_involved, scheduled_for, started_at, ended_at, created_at) VALUES
-('99999999-8888-7777-6666-555555555555', 'e5f6a7b8-c9d0-1234-5678-90abcdef1234', '11111111-2222-3333-4444-555555555555', 'Reuniao de descoberta', 'SCHEDULED', 1800, 'Entender dores e objetivos', 'ONLINE', 'Melhorar eficiencia', 'Contato inicial via email', 'Concorrente X', NOW(), NULL, NULL, NOW())
+('99999999-8888-7777-6666-555555555555', 'e5f6a7b8-c9d0-1234-5678-90abcdef1234', '11111111-2222-3333-4444-555555555555', 'Reunião de descoberta',         'SCHEDULED',   1800, 'Entender dores e objetivos',            'ONLINE',      'Melhorar eficiência operacional',       'Contato inicial via email',         'Concorrente X',              NOW() + interval '3 days',  NULL,                                  NULL,                                  NOW()),
+('aaaaaaaa-1111-2222-3333-444444444444', 'f6a7b8c9-d0e1-2345-6789-0abcdef12345', '21111111-2222-3333-4444-555555555555', 'Apresentação de proposta',       'COMPLETED',   3600, 'Apresentar solução customizada',        'IN_PERSON',   'Reduzir custo de infraestrutura',       'Demo realizada na semana anterior', 'Concorrente Y, Concorrente Z', NOW() - interval '10 days', NOW() - interval '10 days',            NOW() - interval '10 days' + interval '1 hour', NOW() - interval '10 days'),
+('aaaaaaaa-1111-2222-3333-555555555555', 'e5f6a7b8-c9d0-1234-5678-90abcdef1234', '31111111-2222-3333-4444-555555555555', 'Negociação de contrato',         'COMPLETED',   2700, 'Fechar contrato anual',                 'ONLINE',      'Flexibilidade no prazo de pagamento',   'Duas reuniões anteriores de demo',  'Nenhum',                     NOW() - interval '5 days',  NOW() - interval '5 days',             NOW() - interval '5 days' + interval '45 minutes',  NOW() - interval '5 days'),
+('aaaaaaaa-1111-2222-3333-666666666666', 'a7b8c9d0-e1f2-3456-7890-abcdef123456', '41111111-2222-3333-4444-555555555555', 'Follow-up pós-demonstração',     'IN_PROGRESS', 1200, 'Tirar dúvidas técnicas pós-demo',       'ONLINE',      'Entender modelo de precificação',       'Demo realizada ontem',              'Concorrente W',              NOW(),                      NOW(),                                 NULL,                                  NOW()),
+('aaaaaaaa-1111-2222-3333-777777777777', 'f6a7b8c9-d0e1-2345-6789-0abcdef12345', '21111111-2222-3333-4444-555555555555', 'Kickoff de implementação',       'SCHEDULED',   5400, 'Alinhar escopo e cronograma',           'IN_PERSON',   'Garantir suporte durante a migração',   'Contrato assinado na semana passada', 'Nenhum',                   NOW() + interval '7 days',  NULL,                                  NULL,                                  NOW()),
+('aaaaaaaa-1111-2222-3333-888888888888', 'e5f6a7b8-c9d0-1234-5678-90abcdef1234', '11111111-2222-3333-4444-555555555555', 'Revisão trimestral de resultados', 'CANCELLED',   3600, 'Avaliar resultados do último trimestre', 'ONLINE',     'Relatório de desempenho atualizado',    'Reunião mensal recorrente',         'Nenhum',                     NOW() - interval '2 days',  NULL,                                  NULL,                                  NOW() - interval '2 days')
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO meeting_pre_analysis (id, meeting_id, recommended_strategy, key_points, possible_objections, created_at) VALUES
-('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', '99999999-8888-7777-6666-555555555555', '{"focus":"exploration"}'::jsonb, '["Entender processos atuais","Mapear stakeholders"]'::jsonb, '["Orcamento limitado","Prazo curto"]'::jsonb, NOW())
+('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', '99999999-8888-7777-6666-555555555555', '{"focus":"exploration"}'::jsonb,      '["Entender processos atuais","Mapear stakeholders"]'::jsonb,                            '["Orçamento limitado","Prazo curto"]'::jsonb,                      NOW()),
+('bbbbbbbb-1111-cccc-dddd-eeeeeeeeeeee', 'aaaaaaaa-1111-2222-3333-444444444444', '{"focus":"value_selling"}'::jsonb,   '["Destacar ROI da solução","Apresentar casos de sucesso similares","Demo ao vivo"]'::jsonb, '["Preço acima do esperado","Preferência por fornecedor atual"]'::jsonb, NOW() - interval '11 days'),
+('cccccccc-1111-dddd-eeee-ffffffffffff', 'aaaaaaaa-1111-2222-3333-555555555555', '{"focus":"negotiation"}'::jsonb,     '["Negociar desconto por volume","Propor contrato de 12 meses","Validar SLA"]'::jsonb,    '["Condições de pagamento","Cláusulas de rescisão"]'::jsonb,        NOW() - interval '6 days'),
+('dddddddd-1111-eeee-ffff-111111111111', 'aaaaaaaa-1111-2222-3333-666666666666', '{"focus":"technical_clarification"}'::jsonb, '["Responder dúvidas sobre API","Explicar modelo de licenciamento"]'::jsonb,       '["Complexidade de integração","Custo de manutenção"]'::jsonb,      NOW()),
+('eeeeeeee-1111-ffff-aaaa-222222222222', 'aaaaaaaa-1111-2222-3333-777777777777', '{"focus":"onboarding"}'::jsonb,      '["Apresentar equipe de suporte","Definir marcos do projeto","Revisar escopo contratado"]'::jsonb, '["Disponibilidade interna da equipe do cliente"]'::jsonb,     NOW() - interval '1 day'),
+('ffffffff-1111-aaaa-bbbb-333333333333', 'aaaaaaaa-1111-2222-3333-888888888888', '{"focus":"retention"}'::jsonb,       '["Revisar métricas de uso","Identificar oportunidades de upsell"]'::jsonb,               '["Insatisfação com tempo de resposta do suporte"]'::jsonb,        NOW() - interval '3 days')
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO meeting_post_analysis (id, meeting_id, summary, action_items, sentiment_analysis, created_at) VALUES
-('a1a2b3c4-d5e6-7890-1234-56789abcdef0', '99999999-8888-7777-6666-555555555555', 'Cliente demonstrou interesse na proposta e pediu retorno em 7 dias.', '[{"text": "Enviar proposta revisada", "done": false}, {"text": "Agendar próxima etapa", "done": false}]', '{"overall": "positive", "score": 0.81}', '2024-06-10T16:00:00Z')
+('a1a2b3c4-d5e6-7890-1234-56789abcdef0', '99999999-8888-7777-6666-555555555555', 'Cliente demonstrou interesse na proposta e pediu retorno em 7 dias.',
+ '[{"text": "Enviar proposta revisada", "done": false}, {"text": "Agendar próxima etapa", "done": false}]'::jsonb,
+ '{"overall": "positive", "score": 0.81}'::jsonb, NOW() - interval '20 days'),
+('a2b3c4d5-e6f7-8901-2345-67890abcdef1', 'aaaaaaaa-1111-2222-3333-444444444444', 'Reunião muito positiva. Cliente aprovou a proposta técnica e solicitou ajuste no prazo de entrega. Concorrentes foram descartados após comparativo de funcionalidades.',
+ '[{"text": "Ajustar cronograma de entrega para 45 dias", "done": true}, {"text": "Enviar contrato para assinatura", "done": false}, {"text": "Incluir cláusula de suporte estendido", "done": false}]'::jsonb,
+ '{"overall": "very_positive", "score": 0.93}'::jsonb, NOW() - interval '10 days'),
+('a3b4c5d6-e7f8-9012-3456-7890abcdef12', 'aaaaaaaa-1111-2222-3333-555555555555', 'Contrato negociado com sucesso. Cliente aceitou parcelamento em 3x sem juros e assinou LOI. Implementação prevista para início do próximo mês.',
+ '[{"text": "Enviar LOI assinada para o jurídico", "done": true}, {"text": "Agendar kickoff de implementação", "done": false}, {"text": "Provisionar ambiente de homologação", "done": false}]'::jsonb,
+ '{"overall": "positive", "score": 0.87}'::jsonb, NOW() - interval '5 days'),
+('a4b5c6d7-e8f9-0123-4567-890abcdef123', 'aaaaaaaa-1111-2222-3333-666666666666', 'Dúvidas técnicas esclarecidas. Cliente confirmou que a equipe de desenvolvimento iniciará a integração na próxima sprint.',
+ '[{"text": "Enviar documentação técnica da API", "done": false}, {"text": "Criar canal de suporte dedicado no Slack", "done": false}]'::jsonb,
+ '{"overall": "positive", "score": 0.78}'::jsonb, NOW()),
+('a5b6c7d8-e9f0-1234-5678-90abcdef1234', 'aaaaaaaa-1111-2222-3333-777777777777', 'Escopo e cronograma do kickoff alinhados. Equipe do cliente confirmou disponibilidade e marcos do projeto foram definidos em conjunto.',
+ '[{"text": "Compartilhar acesso ao ambiente de homologação", "done": false}, {"text": "Enviar cronograma detalhado por e-mail", "done": false}]'::jsonb,
+ '{"overall": "neutral", "score": 0.65}'::jsonb, NOW() - interval '1 day'),
+('a6b7c8d9-e0f1-2345-6789-0abcdef12345', 'aaaaaaaa-1111-2222-3333-888888888888', 'Reunião cancelada pelo cliente por conflito de agenda. Reagendamento solicitado para a próxima semana.',
+ '[{"text": "Reagendar reunião de revisão trimestral", "done": false}]'::jsonb,
+ '{"overall": "neutral", "score": 0.50}'::jsonb, NOW() - interval '2 days')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO meeting_realtime_insights (id, meeting_id, content, type, description, created_at) VALUES
+-- Reunião de descoberta (99999999)
+('b1b2b3b4-c5d6-7890-1234-56789abcdef1', '99999999-8888-7777-6666-555555555555', 'Cliente mencionou necessidade de integração com ERP existente',        'KEY_POINT',   '{"text": "Requisito técnico crítico que deve constar na proposta"}'::jsonb,           NOW()),
+('b2b3b4b5-c6d7-8901-2345-67890abcdef2', '99999999-8888-7777-6666-555555555555', 'Enviar comparativo de planos até sexta-feira',                          'ACTION_ITEM', '{"text": "Prazo definido pelo cliente durante a reunião"}'::jsonb,                   NOW()),
+('b3b4b5b6-c7d8-9012-3456-7890abcdef13', '99999999-8888-7777-6666-555555555555', 'Orçamento aprovado pela diretoria para Q3',                             'KEY_POINT',   '{"text": "Janela de compra confirmada para o terceiro trimestre"}'::jsonb,            NOW()),
+('b4b5b6b7-c8d9-0123-4567-890abcdef124', '99999999-8888-7777-6666-555555555555', 'Agendar demonstração técnica com o time de TI do cliente',              'ACTION_ITEM', '{"text": "Necessário envolver engenheiro de soluções"}'::jsonb,                      NOW()),
+-- Apresentação de proposta (aaaaaaaa-1111-...-444)
+('c1c2c3c4-d5e6-7890-1234-56789abcdef1', 'aaaaaaaa-1111-2222-3333-444444444444', 'Cliente rejeitou Concorrente Y após comparativo de funcionalidades',    'KEY_POINT',   '{"text": "Diferencial competitivo confirmado pelo próprio cliente"}'::jsonb,          NOW() - interval '10 days'),
+('c2c3c4c5-d6e7-8901-2345-67890abcdef2', 'aaaaaaaa-1111-2222-3333-444444444444', 'Ajustar prazo de entrega de 30 para 45 dias no contrato',               'ACTION_ITEM', '{"text": "Negociação de prazo solicitada pelo gerente de projetos"}'::jsonb,          NOW() - interval '10 days'),
+('c3c4c5c6-d7e8-9012-3456-7890abcdef13', 'aaaaaaaa-1111-2222-3333-444444444444', 'Decisor final é o CTO, não o gerente de TI presente na reunião',       'KEY_POINT',   '{"text": "Mapear aprovação do CTO antes de enviar contrato"}'::jsonb,               NOW() - interval '10 days'),
+('c4c5c6c7-d8e9-0123-4567-890abcdef124', 'aaaaaaaa-1111-2222-3333-444444444444', 'Enviar proposta revisada com novo prazo para aprovação do CTO',         'ACTION_ITEM', '{"text": "Incluir carta de cases de sucesso no setor de tecnologia"}'::jsonb,        NOW() - interval '10 days'),
+-- Negociação de contrato (aaaaaaaa-1111-...-555)
+('d1d2d3d4-e5f6-7890-1234-56789abcdef1', 'aaaaaaaa-1111-2222-3333-555555555555', 'Cliente aceitou parcelamento em 3x sem juros como condição para fechar', 'KEY_POINT',   '{"text": "Condição determinante para o fechamento do contrato"}'::jsonb,             NOW() - interval '5 days'),
+('d2d3d4d5-e6f7-8901-2345-67890abcdef2', 'aaaaaaaa-1111-2222-3333-555555555555', 'Enviar LOI assinada para o time jurídico ainda hoje',                   'ACTION_ITEM', '{"text": "Urgência solicitada pelo cliente para garantir início em novembro"}'::jsonb, NOW() - interval '5 days'),
+('d3d4d5d6-e7f8-9012-3456-7890abcdef13', 'aaaaaaaa-1111-2222-3333-555555555555', 'SLA de 99,5% de uptime é requisito contratual obrigatório',             'KEY_POINT',   '{"text": "Deve constar explicitamente no anexo técnico do contrato"}'::jsonb,        NOW() - interval '5 days'),
+-- Follow-up pós-demo (aaaaaaaa-1111-...-666) — em andamento
+('e1e2e3e4-f5a6-7890-1234-56789abcdef1', 'aaaaaaaa-1111-2222-3333-666666666666', 'Cliente tem dúvida sobre limites de requisições na API',                'KEY_POINT',   '{"text": "Verificar plano contratado e enviar documentação de rate limits"}'::jsonb,  NOW()),
+('e2e3e4e5-f6a7-8901-2345-67890abcdef2', 'aaaaaaaa-1111-2222-3333-666666666666', 'Enviar documentação técnica da API REST com exemplos de integração',    'ACTION_ITEM', '{"text": "Cliente tem equipe de devs pronta para iniciar integração"}'::jsonb,       NOW()),
+-- Kickoff de implementação (aaaaaaaa-1111-...-777)
+('f1f2f3f4-a5b6-7890-1234-56789abcdef1', 'aaaaaaaa-1111-2222-3333-777777777777', 'Marcos do projeto definidos: entrega em 3 fases de 15 dias cada',       'KEY_POINT',   '{"text": "Cronograma aprovado por ambas as partes na reunião"}'::jsonb,              NOW() - interval '1 day'),
+('f2f3f4f5-a6b7-8901-2345-67890abcdef2', 'aaaaaaaa-1111-2222-3333-777777777777', 'Compartilhar credenciais do ambiente de homologação até amanhã',        'ACTION_ITEM', '{"text": "Equipe do cliente aguarda acesso para iniciar testes"}'::jsonb,            NOW() - interval '1 day'),
+-- Revisão trimestral cancelada (aaaaaaaa-1111-...-888)
+('f3f4f5f6-a7b8-9012-3456-7890abcdef13', 'aaaaaaaa-1111-2222-3333-888888888888', 'Reunião cancelada por conflito de agenda do lado do cliente',           'KEY_POINT',   '{"text": "Cliente solicitou reagendamento via e-mail antes do horário"}'::jsonb,     NOW() - interval '2 days'),
+('f4f5f6f7-a8b9-0123-4567-890abcdef124', 'aaaaaaaa-1111-2222-3333-888888888888', 'Reagendar revisão trimestral para a semana seguinte',                   'ACTION_ITEM', '{"text": "Prioridade alta para não perder a janela do trimestre"}'::jsonb,           NOW() - interval '2 days')
 ON CONFLICT (id) DO NOTHING;

--- a/domain/src/main/java/com/salespilot/api/domain/repository/MeetingPostAnalysisRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/MeetingPostAnalysisRepository.java
@@ -7,4 +7,5 @@ import java.util.UUID;
 
 public interface MeetingPostAnalysisRepository {
     Optional<MeetingPostAnalysis> findByMeetingId(UUID meetingId);
+    double getAverageSuccessRate();
 }

--- a/domain/src/main/java/com/salespilot/api/domain/repository/MeetingPostAnalysisRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/MeetingPostAnalysisRepository.java
@@ -7,5 +7,6 @@ import java.util.UUID;
 
 public interface MeetingPostAnalysisRepository {
     Optional<MeetingPostAnalysis> findByMeetingId(UUID meetingId);
-    double getAverageSuccessRate();
+    Double getAverageSuccessRate();
+    Double getAverageFeelingByCollaborator(UUID collaboratorId);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
@@ -88,8 +88,8 @@ public class UseCaseConfig {
     }
 
     @Bean
-    public GetAllMeetingsUseCase getAllMeetingsUseCase(MeetingRepository repository, ClientRepository clientRepository, CollaboratorRepository collaboratorRepository) {
-        return new GetAllMeetingsUseCase(repository, clientRepository, collaboratorRepository);
+    public GetAllMeetingsUseCase getAllMeetingsUseCase(MeetingRepository repository, MeetingPostAnalysisRepository meetingPostAnalysisRepository, ClientRepository clientRepository, CollaboratorRepository collaboratorRepository) {
+        return new GetAllMeetingsUseCase(repository, meetingPostAnalysisRepository, clientRepository, collaboratorRepository);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
@@ -77,8 +77,8 @@ public class UseCaseConfig {
     }
 
     @Bean
-    public GetAllSellersUseCase getAllSellersUseCase(CollaboratorRepository repository, CompanyRepository companyRepository, MeetingRepository meetingRepository) {
-        return new GetAllSellersUseCase(repository, companyRepository, meetingRepository);
+    public GetAllSellersUseCase getAllSellersUseCase(CollaboratorRepository repository, CompanyRepository companyRepository, MeetingRepository meetingRepository, MeetingPostAnalysisRepository meetingPostAnalysisRepository) {
+        return new GetAllSellersUseCase(repository, companyRepository, meetingRepository, meetingPostAnalysisRepository);
     }
     
 

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisJpaRepository.java
@@ -11,4 +11,7 @@ import java.util.UUID;
 public interface MeetingPostAnalysisJpaRepository extends JpaRepository<MeetingPostAnalysisEntity, UUID> {
     @Query("SELECT mpa FROM MeetingPostAnalysisEntity mpa WHERE mpa.meeting.id = :meetingId")
     Optional<MeetingPostAnalysisEntity> findByMeetingId(@Param("meetingId") UUID meetingId);
+
+    @Query(value = "SELECT AVG(CAST(sentiment_analysis->>'score' AS DOUBLE PRECISION)) FROM meeting_post_analysis WHERE sentiment_analysis IS NOT NULL", nativeQuery = true)
+    Optional<Double> findAverageSuccessRate();
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisJpaRepository.java
@@ -14,4 +14,13 @@ public interface MeetingPostAnalysisJpaRepository extends JpaRepository<MeetingP
 
     @Query(value = "SELECT AVG(CAST(sentiment_analysis->>'score' AS DOUBLE PRECISION)) FROM meeting_post_analysis WHERE sentiment_analysis IS NOT NULL", nativeQuery = true)
     Optional<Double> findAverageSuccessRate();
+
+    @Query(value = """
+            SELECT AVG(CAST(mpa.sentiment_analysis->>'score' AS DOUBLE PRECISION))
+            FROM meeting_post_analysis mpa
+            JOIN meetings m ON m.id = mpa.meeting_id
+            WHERE m.collaborator_id = :collaboratorId
+            AND mpa.sentiment_analysis IS NOT NULL
+            """, nativeQuery = true)
+    Optional<Double> findAverageScoreByCollaboratorId(@Param("collaboratorId") UUID collaboratorId);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisRepositoryImpl.java
@@ -23,4 +23,9 @@ public class MeetingPostAnalysisRepositoryImpl implements MeetingPostAnalysisRep
         return meetingPostAnalysisJpaRepository.findByMeetingId(meetingId)
                 .map(mapper::toDomain);
     }
+
+    @Override
+    public double getAverageSuccessRate() {
+        return meetingPostAnalysisJpaRepository.findAverageSuccessRate().orElse(0.0);
+    }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisRepositoryImpl.java
@@ -25,7 +25,12 @@ public class MeetingPostAnalysisRepositoryImpl implements MeetingPostAnalysisRep
     }
 
     @Override
-    public double getAverageSuccessRate() {
-        return meetingPostAnalysisJpaRepository.findAverageSuccessRate().orElse(0.0);
+    public Double getAverageSuccessRate() {
+        return meetingPostAnalysisJpaRepository.findAverageSuccessRate().orElse(null);
+    }
+
+    @Override
+    public Double getAverageFeelingByCollaborator(UUID collaboratorId) {
+        return meetingPostAnalysisJpaRepository.findAverageScoreByCollaboratorId(collaboratorId).orElse(null);
     }
 }


### PR DESCRIPTION
## Issue relacionada

Sem referência

## O que foi implementado?

### Migração de `successRate` para `meeting_post_analysis`

- Removido o método `findAverageSuccessRate` de `MeetingsJpaRepository` e `getSuccessRate` de `MeetingRepository`, que consultavam uma coluna inexistente em `meetings`
- Adicionada query nativa em `MeetingPostAnalysisJpaRepository` calculando a média de `sentiment_analysis->>'score'` diretamente da tabela `meeting_post_analysis`
- Novo método `getAverageSuccessRate()` exposto via `MeetingPostAnalysisRepository` e implementado em `MeetingPostAnalysisRepositoryImpl`
- `GetAllMeetingsUseCase` atualizado para injetar `MeetingPostAnalysisRepository` e consumir o novo método

### `average_feeling` dinâmico no `GET /api/collaborators/sellers`

- Adicionada query nativa em `MeetingPostAnalysisJpaRepository` calculando a média de `score` por `collaborator_id` via join com `meetings`
- Novo método `getAverageFeelingByCollaborator(UUID)` em `MeetingPostAnalysisRepository` e sua implementação
- `GetAllSellersUseCase` atualizado para calcular o valor dinamicamente em vez de ler a coluna estática `average_feeling` do colaborador

### Retorno nullable em métricas de sentimento

- `getAverageSuccessRate()` e `getAverageFeelingByCollaborator()` retornam `null` quando não há análises, em vez de `0.0`
- `SummaryResponseDTO.successRate` e `SellerResponseDTO.averageFeeling` alterados de `double`/`Integer` para `Double`, serializando como `null` no JSON

### Dados de seed (`data.sql`)

- Adicionados 2 novos colaboradores do tipo `SELLER`: Marcos Pereira e Julia Fernandes
- Adicionados 3 novos clientes com seus respectivos sellers responsáveis
- Adicionadas 5 novas reuniões com status variados (`COMPLETED`, `IN_PROGRESS`, `SCHEDULED`, `CANCELLED`), todas vinculadas a colaboradores do tipo `SELLER`
- Adicionados `meeting_pre_analysis`, `meeting_post_analysis` e `meeting_realtime_insights` para todas as reuniões
- Corrigido `duration_seconds` para não aceitar `NULL`

## Por que essa mudança é necessária?

O `successRate` e o `average_feeling` eram calculados a partir de dados inexistentes ou estáticos. A fonte correta dessas métricas é o campo `sentiment_analysis.score` dentro de `meeting_post_analysis`, que é populado pela análise de IA após cada reunião. Além disso, os dados de seed estavam inconsistentes — reuniões atribuídas a não-vendedores e campos obrigatórios nulos.

## Como testar?

1. Subir o banco com o `data.sql` atualizado
2. `GET /api/collaborators/sellers` — verificar que `averageFeeling` é um `Double` calculado dinamicamente; sellers sem reuniões devem retornar `null`
3. `GET /api/meetings` — verificar que `successRate` no summary reflete a média dos scores de `meeting_post_analysis`; sem análises deve retornar `null`

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças