### PR TITLE
ci: add CODEOWNERS for automatic review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @SalesPilot-AGES/backend-reviewers


### PR DESCRIPTION
## Issue relacionada

N/A — configuração de infra do repositório.

## O que foi implementado?

Adicionado arquivo `.github/CODEOWNERS` configurando o time de revisores responsável pelo repositório. A partir deste PR, toda PR aberta terá o review solicitado automaticamente para o time correspondente.

## Por que essa mudança é necessária?

Padronizar e automatizar o processo de code review, garantindo que os revisores corretos sejam sempre notificados.

## Como testar?

Após o merge, abra uma PR de teste e verifique se o time de revisores é adicionado automaticamente como reviewer.

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças