### PR TITLE
feat: discord pr notification

### DIFF
--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -24,13 +24,13 @@ jobs:
             BODY="Sem descrição."
           fi
 
-          TRUNCATED_BODY=$(echo "$BODY" | head -c 900)
-          if [ ${#BODY} -gt 900 ]; then
+          TRUNCATED_BODY=$(echo "$BODY" | cut -c1-900)
+          if [ $(echo "$BODY" | wc -m) -gt 900 ]; then
             TRUNCATED_BODY="${TRUNCATED_BODY}..."
           fi
 
           THREAD_NAME="PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}"
-          THREAD_NAME=$(echo "$THREAD_NAME" | head -c 100)
+          THREAD_NAME=$(echo "$THREAD_NAME" | cut -c1-100)
 
           PAYLOAD=$(jq -n \
             --arg thread_name "$THREAD_NAME" \
@@ -58,7 +58,7 @@ jobs:
               }]
             }')
 
-          curl -s -o /dev/null -w "%{http_code}" \
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --fail \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD" \
-            "$DISCORD_WEBHOOK_URL"
+            "$DISCORD_WEBHOOK_URL") || (echo "Discord webhook failed with HTTP $HTTP_CODE"; exit 1)

--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -58,7 +58,8 @@ jobs:
               }]
             }')
 
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --fail \
+          RESPONSE=$(curl -s -w "\nHTTP_%{http_code}" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD" \
-            "$DISCORD_WEBHOOK_URL") || (echo "Discord webhook failed with HTTP $HTTP_CODE"; exit 1)
+            "$DISCORD_WEBHOOK_URL")
+          echo "$RESPONSE"

--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -1,0 +1,64 @@
+name: Discord PR Notification
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+    branches:
+      - main
+      - development
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Send PR notification to Discord Forum
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          ASSIGNEES=$(echo '${{ toJson(github.event.pull_request.assignees) }}' | jq -r '[.[].login] | if length == 0 then "Nenhum" else join(", ") end')
+          REVIEWERS=$(echo '${{ toJson(github.event.pull_request.requested_reviewers) }}' | jq -r '[.[].login] | if length == 0 then "Nenhum" else join(", ") end')
+
+          BODY="${{ github.event.pull_request.body }}"
+          if [ -z "$BODY" ]; then
+            BODY="Sem descrição."
+          fi
+
+          TRUNCATED_BODY=$(echo "$BODY" | head -c 900)
+          if [ ${#BODY} -gt 900 ]; then
+            TRUNCATED_BODY="${TRUNCATED_BODY}..."
+          fi
+
+          THREAD_NAME="PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}"
+          THREAD_NAME=$(echo "$THREAD_NAME" | head -c 100)
+
+          PAYLOAD=$(jq -n \
+            --arg thread_name "$THREAD_NAME" \
+            --arg pr_url "${{ github.event.pull_request.html_url }}" \
+            --arg author "${{ github.event.pull_request.user.login }}" \
+            --arg base "${{ github.event.pull_request.base.ref }}" \
+            --arg head "${{ github.event.pull_request.head.ref }}" \
+            --arg assignees "$ASSIGNEES" \
+            --arg reviewers "$REVIEWERS" \
+            --arg body "$TRUNCATED_BODY" \
+            '{
+              thread_name: $thread_name,
+              embeds: [{
+                title: $thread_name,
+                url: $pr_url,
+                color: 5814783,
+                fields: [
+                  { name: "Autor", value: $author, inline: true },
+                  { name: "Branch", value: ("`" + $head + "` → `" + $base + "`"), inline: true },
+                  { name: "Assignees", value: $assignees, inline: true },
+                  { name: "Reviewers", value: $reviewers, inline: true },
+                  { name: "Descrição", value: $body, inline: false }
+                ],
+                footer: { text: "SalesPilot Backend" }
+              }]
+            }')
+
+          curl -s -o /dev/null -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## Issue relacionada

  Não há issue relacionada.

## O que foi implementado?

  Adicionado workflow do GitHub Actions                                         
  (.github/workflows/discord-pr-notify.yml) que envia uma notificação automática
   em um canal Forum do Discord sempre que um PR é aberto ou marcado como pronto
   para revisão. A notificação inclui autor, branch, assignees, reviewers e
  descrição do PR em um post/thread separado por PR.

## Por que essa mudança é necessária?

  Centralizar a comunicação do time sobre novos PRs no Discord, evitando que    
  aberturas passem despercebidas e facilitando a organização das revisões por
  tópico. 

## Como testar?

  1. Abrir um PR apontando para main ou development
  2. Verificar se um novo post/thread foi criado no canal Forum do Discord com
  as informações do PR     

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças