### PR TITLE
feat: create endpoint for company status (donut chart)

### DIFF
--- a/application/src/main/java/com/salespilot/api/application/dto/CompanyStatusCountDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/CompanyStatusCountDTO.java
@@ -1,7 +1,7 @@
 package com.salespilot.api.application.dto;
 
-public record DonutChartDataResponseDTO(
+public record CompanyStatusCountDTO(
     String label,
     Long value
 ) {
-}
+} 

--- a/application/src/main/java/com/salespilot/api/application/dto/DonutChartDataResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/DonutChartDataResponseDTO.java
@@ -1,0 +1,7 @@
+package com.salespilot.api.application.dto;
+
+public record DonutChartDataResponseDTO(
+    String label,
+    Long value
+) {
+}

--- a/application/src/main/java/com/salespilot/api/application/dto/GroupCompanyCountResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/GroupCompanyCountResponseDTO.java
@@ -3,7 +3,7 @@ package com.salespilot.api.application.dto;
 import java.util.List;
 
 public record GroupCompanyCountResponseDTO(
-    List<DonutChartDataResponseDTO> data,
+    List<CompanyStatusCountDTO> data,
     Long total
 ) {
 }

--- a/application/src/main/java/com/salespilot/api/application/dto/GroupCompanyCountResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/GroupCompanyCountResponseDTO.java
@@ -1,0 +1,9 @@
+package com.salespilot.api.application.dto;
+
+import java.util.List;
+
+public record GroupCompanyCountResponseDTO(
+    List<DonutChartDataResponseDTO> data,
+    Long total
+) {
+}

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetGroupedCompaniesCountUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetGroupedCompaniesCountUseCase.java
@@ -1,9 +1,8 @@
 package com.salespilot.api.application.usecase;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import com.salespilot.api.application.dto.DonutChartDataResponseDTO;
+import com.salespilot.api.application.dto.CompanyStatusCountDTO;
 import com.salespilot.api.application.dto.GroupCompanyCountResponseDTO;
 import com.salespilot.api.domain.repository.CompanyRepository;
 
@@ -14,18 +13,31 @@ public class GetGroupedCompaniesCountUseCase {
         this.companyRepository = companyRepository;
     }
 
-    public GroupCompanyCountResponseDTO execute(){
-        List<DonutChartDataResponseDTO> donutDtoList = new ArrayList<>();
-        DonutChartDataResponseDTO active = new DonutChartDataResponseDTO("Ativas", companyRepository.countCompanyActiveGrouped(true));
-        DonutChartDataResponseDTO inactive = new DonutChartDataResponseDTO("Inativas", companyRepository.countCompanyActiveGrouped(false));
-        donutDtoList.add(active);
-        donutDtoList.add(inactive);
+    public GroupCompanyCountResponseDTO execute() {
 
-        GroupCompanyCountResponseDTO dto = new GroupCompanyCountResponseDTO(
-            donutDtoList,
-            companyRepository.countAll()
+        List<CompanyStatusCountDTO> data = companyRepository.countCompaniesGroupedByStatus()
+            .stream()
+            .map(this::mapToDto)
+            .toList();
+
+        Long total = data.stream()
+            .mapToLong(CompanyStatusCountDTO::value)
+            .sum();
+
+        return new GroupCompanyCountResponseDTO(
+            data,
+            total
         );
+    }
 
-        return dto;
+    private CompanyStatusCountDTO mapToDto(Object[] item) {
+
+        boolean active = (Boolean) item[0];
+        long count = ((Number) item[1]).longValue();
+
+        return new CompanyStatusCountDTO(
+                active ? "Ativas" : "Inativas",
+                count
+        );
     }
 }

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetGroupedCompaniesCountUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetGroupedCompaniesCountUseCase.java
@@ -1,0 +1,31 @@
+package com.salespilot.api.application.usecase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.salespilot.api.application.dto.DonutChartDataResponseDTO;
+import com.salespilot.api.application.dto.GroupCompanyCountResponseDTO;
+import com.salespilot.api.domain.repository.CompanyRepository;
+
+public class GetGroupedCompaniesCountUseCase {
+    private final CompanyRepository companyRepository;
+
+    public GetGroupedCompaniesCountUseCase(CompanyRepository companyRepository){
+        this.companyRepository = companyRepository;
+    }
+
+    public GroupCompanyCountResponseDTO execute(){
+        List<DonutChartDataResponseDTO> donutDtoList = new ArrayList<>();
+        DonutChartDataResponseDTO active = new DonutChartDataResponseDTO("Ativas", companyRepository.countCompanyActiveGrouped(true));
+        DonutChartDataResponseDTO inactive = new DonutChartDataResponseDTO("Inativas", companyRepository.countCompanyActiveGrouped(false));
+        donutDtoList.add(active);
+        donutDtoList.add(inactive);
+
+        GroupCompanyCountResponseDTO dto = new GroupCompanyCountResponseDTO(
+            donutDtoList,
+            companyRepository.countAll()
+        );
+
+        return dto;
+    }
+}

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetGroupedCompaniesCountUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetGroupedCompaniesCountUseCase.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.salespilot.api.application.dto.CompanyStatusCountDTO;
 import com.salespilot.api.application.dto.GroupCompanyCountResponseDTO;
+import com.salespilot.api.domain.model.CompanyStatusCount;
 import com.salespilot.api.domain.repository.CompanyRepository;
 
 public class GetGroupedCompaniesCountUseCase {
@@ -15,7 +16,8 @@ public class GetGroupedCompaniesCountUseCase {
 
     public GroupCompanyCountResponseDTO execute() {
 
-        List<CompanyStatusCountDTO> data = companyRepository.countCompaniesGroupedByStatus()
+        List<CompanyStatusCountDTO> data = companyRepository
+            .countCompaniesGroupedByStatus()
             .stream()
             .map(this::mapToDto)
             .toList();
@@ -24,20 +26,10 @@ public class GetGroupedCompaniesCountUseCase {
             .mapToLong(CompanyStatusCountDTO::value)
             .sum();
 
-        return new GroupCompanyCountResponseDTO(
-            data,
-            total
-        );
+        return new GroupCompanyCountResponseDTO(data, total);
     }
 
-    private CompanyStatusCountDTO mapToDto(Object[] item) {
-
-        boolean active = (Boolean) item[0];
-        long count = ((Number) item[1]).longValue();
-
-        return new CompanyStatusCountDTO(
-                active ? "Ativas" : "Inativas",
-                count
-        );
+    private CompanyStatusCountDTO mapToDto(CompanyStatusCount item) {
+        return new CompanyStatusCountDTO(item.active() ? "Ativas" : "Inativas", item.total());
     }
 }

--- a/domain/src/main/java/com/salespilot/api/domain/model/CompanyStatusCount.java
+++ b/domain/src/main/java/com/salespilot/api/domain/model/CompanyStatusCount.java
@@ -1,0 +1,7 @@
+package com.salespilot.api.domain.model;
+
+public record CompanyStatusCount(
+    boolean active,
+    Long total
+) {
+}

--- a/domain/src/main/java/com/salespilot/api/domain/repository/CompanyRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/CompanyRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.salespilot.api.domain.entity.Company;
+import com.salespilot.api.domain.model.CompanyStatusCount;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,5 +16,5 @@ public interface CompanyRepository {
     Page<Company> getAllCompanies(String name, String taxId, String plan, Boolean active, Pageable pageable);
     Optional<Company> getCompanyById(UUID id);
     Optional<Company> updateCompany(UUID id, String name, String plan, boolean active);
-    List<Object[]> countCompaniesGroupedByStatus();
+    List<CompanyStatusCount> countCompaniesGroupedByStatus();
 }

--- a/domain/src/main/java/com/salespilot/api/domain/repository/CompanyRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/CompanyRepository.java
@@ -14,4 +14,6 @@ public interface CompanyRepository {
     Page<Company> getAllCompanies(String name, String taxId, String plan, Boolean active, Pageable pageable);
     Optional<Company> getCompanyById(UUID id);
     Optional<Company> updateCompany(UUID id, String name, String plan, boolean active);
+    Long countAll();
+    Long countCompanyActiveGrouped(boolean active);
 }

--- a/domain/src/main/java/com/salespilot/api/domain/repository/CompanyRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/CompanyRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.salespilot.api.domain.entity.Company;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -14,6 +15,5 @@ public interface CompanyRepository {
     Page<Company> getAllCompanies(String name, String taxId, String plan, Boolean active, Pageable pageable);
     Optional<Company> getCompanyById(UUID id);
     Optional<Company> updateCompany(UUID id, String name, String plan, boolean active);
-    Long countAll();
-    Long countCompanyActiveGrouped(boolean active);
+    List<Object[]> countCompaniesGroupedByStatus();
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.salespilot.api.application.usecase.GetAllCompaniesUseCase;
 import com.salespilot.api.application.usecase.GetCompanyByIdUseCase;
+import com.salespilot.api.application.usecase.GetGroupedCompaniesCountUseCase;
 import com.salespilot.api.application.usecase.GetSellerByIdUseCase;
 import com.salespilot.api.application.usecase.GetSystemStatusUseCase;
 import com.salespilot.api.application.usecase.PostCompanyUseCase;
@@ -105,5 +106,10 @@ public class UseCaseConfig {
     @Bean
     public GetMeetingInsightUseCase getMeetingInsightUseCase(MeetingRealtimeInsightRepository meetingRealtimeInsightRepository, MeetingRepository meetingRepository) {
         return new GetMeetingInsightUseCase(meetingRealtimeInsightRepository, meetingRepository);
+    }
+
+    @Bean
+    public GetGroupedCompaniesCountUseCase getGroupedCompaniesCountUseCase(CompanyRepository companyRepository) {
+        return new GetGroupedCompaniesCountUseCase(companyRepository);
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyJpaRepository.java
@@ -1,13 +1,16 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+
 import com.salespilot.api.infrastructure.persistence.jpa.entity.CompanyEntity;
 
 
@@ -17,4 +20,11 @@ public interface CompanyJpaRepository extends JpaRepository<CompanyEntity, UUID>
     boolean existsByTaxId(String taxId);
     
     Optional<CompanyEntity> findByTaxId(String taxId);
+
+    @Query("""
+        SELECT c.active, COUNT(c)
+        FROM CompanyEntity c
+        GROUP BY c.active
+    """)
+    List<Object[]> countCompaniesGroupedByStatus();
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.salespilot.api.domain.entity.Company;
+import com.salespilot.api.domain.model.CompanyStatusCount;
 import com.salespilot.api.domain.repository.CompanyRepository;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.CompanyEntity;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.CompanySubscriptions;
@@ -129,7 +130,25 @@ public class CompanyRepositoryImpl implements CompanyRepository {
     }
 
     @Override
-    public List<Object[]> countCompaniesGroupedByStatus() {
-        return companyJpaRepository.countCompaniesGroupedByStatus();
+    public List<CompanyStatusCount> countCompaniesGroupedByStatus() {
+        return companyJpaRepository
+            .countCompaniesGroupedByStatus()
+            .stream()
+            .map(this::mapToCompanyStatusCount)
+            .toList();
+    }
+
+    private CompanyStatusCount mapToCompanyStatusCount(Object[] item) {
+        if (item == null || item.length < 2) {
+            throw new IllegalStateException("Resultado inválido da query de companies");
+        }
+
+        Boolean active = (Boolean) item[0];
+        Number total = (Number) item[1];
+
+        return new CompanyStatusCount(
+            Boolean.TRUE.equals(active),
+            total.longValue()
+        );
     }    
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -128,15 +129,7 @@ public class CompanyRepositoryImpl implements CompanyRepository {
     }
 
     @Override
-    public Long countAll() {
-        return companyJpaRepository.count();
-    }
-
-    @Override
-    public Long countCompanyActiveGrouped(boolean active) {
-        Specification<CompanyEntity> spec = Specification.where(
-            CompanySpecification.isActiveEquals(active)
-        );
-        return companyJpaRepository.count(spec);
+    public List<Object[]> countCompaniesGroupedByStatus() {
+        return companyJpaRepository.countCompaniesGroupedByStatus();
     }    
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
@@ -126,4 +126,17 @@ public class CompanyRepositoryImpl implements CompanyRepository {
         subscription.setUpdatedAt(LocalDateTime.now());
         companySubscriptionsJpaRepository.save(subscription);
     }
+
+    @Override
+    public Long countAll() {
+        return companyJpaRepository.count();
+    }
+
+    @Override
+    public Long countCompanyActiveGrouped(boolean active) {
+        Specification<CompanyEntity> spec = Specification.where(
+            CompanySpecification.isActiveEquals(active)
+        );
+        return companyJpaRepository.count(spec);
+    }    
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
@@ -129,6 +129,7 @@ public class CompanyRepositoryImpl implements CompanyRepository {
         companySubscriptionsJpaRepository.save(subscription);
     }
 
+    @Transactional(readOnly = true)
     @Override
     public List<CompanyStatusCount> countCompaniesGroupedByStatus() {
         return companyJpaRepository

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
@@ -1,0 +1,30 @@
+package com.salespilot.api.presentation.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.salespilot.api.application.dto.GroupCompanyCountResponseDTO;
+import com.salespilot.api.application.usecase.GetGroupedCompaniesCountUseCase;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+
+@Tag(name = "Dashboard")
+@RestController
+@RequestMapping("/api/dashboard")
+public class DashboardController {
+    private final GetGroupedCompaniesCountUseCase getGroupedCompaniesCountUseCase;
+
+    public DashboardController(GetGroupedCompaniesCountUseCase getGroupedCompaniesCountUseCase){
+        this.getGroupedCompaniesCountUseCase = getGroupedCompaniesCountUseCase;
+    }
+
+    @GetMapping("/companies-status")
+    public ResponseEntity<GroupCompanyCountResponseDTO> getGroupedCompaniesCount() {
+        return ResponseEntity.ok(getGroupedCompaniesCountUseCase.execute());
+    }
+    
+}

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
@@ -6,6 +6,12 @@ import org.springframework.web.bind.annotation.RestController;
 import com.salespilot.api.application.dto.GroupCompanyCountResponseDTO;
 import com.salespilot.api.application.usecase.GetGroupedCompaniesCountUseCase;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.http.ResponseEntity;
@@ -18,10 +24,28 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class DashboardController {
     private final GetGroupedCompaniesCountUseCase getGroupedCompaniesCountUseCase;
 
+    private static final String COMPANY_STATUS_RESPONSE_EXAMPLE = """
+            {
+                "data": [
+                    { "label": "Ativas", "value": 6 },
+                    { "label": "Inativas", "value": 1 }
+                ],
+                "total": 7
+            }
+            """;
+
     public DashboardController(GetGroupedCompaniesCountUseCase getGroupedCompaniesCountUseCase){
         this.getGroupedCompaniesCountUseCase = getGroupedCompaniesCountUseCase;
     }
 
+
+    @Operation(summary = "Retornar empresas ativas e inativas", description = "Retorna a quantidade de empresas ativas e inativas")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Dados retornados com sucesso",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = GroupCompanyCountResponseDTO.class),
+                            examples = @ExampleObject(value = COMPANY_STATUS_RESPONSE_EXAMPLE))),
+    })
     @GetMapping("/companies-status")
     public ResponseEntity<GroupCompanyCountResponseDTO> getGroupedCompaniesCount() {
         return ResponseEntity.ok(getGroupedCompaniesCountUseCase.execute());


### PR DESCRIPTION
## Issue relacionada

https://github.com/SalesPilot-AGES/Backend/issues/41

## O que foi implementado?

Foi criado um endpoint para retornar um uma lista com a quantidade de empresas ativas e inativas

## Por que essa mudança é necessária?

Faz parte do previsto para sprint 3

## Como testar?

Fazer uma requisição GET em http://localhost:8080/api/dashboard/companies-status

## Testes

<img width="842" height="440" alt="Captura de tela 2026-05-16 154828" src="https://github.com/user-attachments/assets/5dd6196a-b9fd-4955-afa3-e5d45354ca64" />

## Checklist

- [ X ] O código foi revisado pelo próprio autor antes de abrir o MR
- [ X ] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças