### PR TITLE
feat: create endpoint for total meetings by month

### DIFF
--- a/application/src/main/java/com/salespilot/api/application/dto/MeetingsGroupedByMonthResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/MeetingsGroupedByMonthResponseDTO.java
@@ -1,0 +1,8 @@
+package com.salespilot.api.application.dto;
+
+import java.util.List;
+
+public record MeetingsGroupedByMonthResponseDTO(
+    List<MonthAndTotalDTO> data
+) {
+} 

--- a/application/src/main/java/com/salespilot/api/application/dto/MonthAndTotalDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/MonthAndTotalDTO.java
@@ -1,0 +1,10 @@
+package com.salespilot.api.application.dto;
+
+import java.time.LocalDateTime;
+
+public record MonthAndTotalDTO(
+    LocalDateTime month,
+    String monthLabel,
+    Long total
+) {
+} 

--- a/application/src/main/java/com/salespilot/api/application/exception/InvalidPeriodException.java
+++ b/application/src/main/java/com/salespilot/api/application/exception/InvalidPeriodException.java
@@ -1,0 +1,7 @@
+package com.salespilot.api.application.exception;
+
+public class InvalidPeriodException extends RuntimeException{
+    public InvalidPeriodException(){
+        super("Período inválido");
+    }
+}

--- a/application/src/main/java/com/salespilot/api/application/exception/InvalidPeriodException.java
+++ b/application/src/main/java/com/salespilot/api/application/exception/InvalidPeriodException.java
@@ -1,7 +1,9 @@
 package com.salespilot.api.application.exception;
 
+import java.time.LocalDate;
+
 public class InvalidPeriodException extends RuntimeException{
-    public InvalidPeriodException(){
-        super("Período inválido");
+    public InvalidPeriodException(LocalDate start, LocalDate end){
+        super("Período inválido: " + start + ", " + end);
     }
 }

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetTotalMeetingsGroupedByMonthUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetTotalMeetingsGroupedByMonthUseCase.java
@@ -1,0 +1,43 @@
+package com.salespilot.api.application.usecase;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.TextStyle;
+import java.util.List;
+import java.util.Locale;
+
+import com.salespilot.api.application.dto.MeetingsGroupedByMonthResponseDTO;
+import com.salespilot.api.application.dto.MonthAndTotalDTO;
+import com.salespilot.api.application.utils.DashboardPeriodUtils;
+import com.salespilot.api.domain.repository.MeetingRepository;
+
+public class GetTotalMeetingsGroupedByMonthUseCase {
+    private final MeetingRepository meetingRepository;
+
+    public GetTotalMeetingsGroupedByMonthUseCase(MeetingRepository meetingRepository){
+        this.meetingRepository = meetingRepository;
+    }
+
+    public MeetingsGroupedByMonthResponseDTO execute(String period, LocalDate start, LocalDate end){
+        LocalDateTime[] range =DashboardPeriodUtils.resolve(period, start, end);
+
+        LocalDateTime startDate = range[0];
+        LocalDateTime endDate = range[1];
+
+        List<MonthAndTotalDTO> data = meetingRepository.getMeetingsGroupedByMonth(startDate, endDate).stream().map(this::map).toList();
+        return new MeetingsGroupedByMonthResponseDTO(data);
+    }
+
+    private MonthAndTotalDTO map(Object[] item) {
+        LocalDateTime month = (LocalDateTime) item[0];
+        Long total = ((Number) item[1]).longValue();
+
+        String monthLabel = month.getMonth().getDisplayName(TextStyle.SHORT, Locale.of("pt", "BR")).replace(".", "");
+
+        return new MonthAndTotalDTO(month, capitalize(monthLabel),total);
+    }
+
+    private String capitalize(String monthLabel) {
+        return monthLabel.substring(0, 1).toUpperCase() + monthLabel.substring(1);
+    }
+}

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetTotalMeetingsGroupedByMonthUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetTotalMeetingsGroupedByMonthUseCase.java
@@ -2,13 +2,12 @@ package com.salespilot.api.application.usecase;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.TextStyle;
 import java.util.List;
-import java.util.Locale;
 
 import com.salespilot.api.application.dto.MeetingsGroupedByMonthResponseDTO;
 import com.salespilot.api.application.dto.MonthAndTotalDTO;
 import com.salespilot.api.application.utils.DashboardPeriodUtils;
+import com.salespilot.api.domain.model.MonthAndTotal;
 import com.salespilot.api.domain.repository.MeetingRepository;
 
 public class GetTotalMeetingsGroupedByMonthUseCase {
@@ -28,16 +27,7 @@ public class GetTotalMeetingsGroupedByMonthUseCase {
         return new MeetingsGroupedByMonthResponseDTO(data);
     }
 
-    private MonthAndTotalDTO map(Object[] item) {
-        LocalDateTime month = (LocalDateTime) item[0];
-        Long total = ((Number) item[1]).longValue();
-
-        String monthLabel = month.getMonth().getDisplayName(TextStyle.SHORT, Locale.of("pt", "BR")).replace(".", "");
-
-        return new MonthAndTotalDTO(month, capitalize(monthLabel),total);
-    }
-
-    private String capitalize(String monthLabel) {
-        return monthLabel.substring(0, 1).toUpperCase() + monthLabel.substring(1);
+    private MonthAndTotalDTO map(MonthAndTotal item) {
+        return new MonthAndTotalDTO(item.month(), item.monthLabel(), item.total());
     }
 }

--- a/application/src/main/java/com/salespilot/api/application/utils/DashboardPeriodUtils.java
+++ b/application/src/main/java/com/salespilot/api/application/utils/DashboardPeriodUtils.java
@@ -18,12 +18,12 @@ public class DashboardPeriodUtils {
                 start = end.minusDays(90);
             case "custom" -> {
                 if (startDate == null || endDate == null) {
-                    throw new InvalidPeriodException();
+                    throw new InvalidPeriodException(startDate, endDate);
                 }
                 start = startDate.atStartOfDay();
                 end = endDate.atTime(23, 59, 59);
             }
-            default -> throw new InvalidPeriodException();
+            default -> throw new InvalidPeriodException(startDate, endDate);
         }
 
         return new LocalDateTime[] { start, end };

--- a/application/src/main/java/com/salespilot/api/application/utils/DashboardPeriodUtils.java
+++ b/application/src/main/java/com/salespilot/api/application/utils/DashboardPeriodUtils.java
@@ -1,0 +1,31 @@
+package com.salespilot.api.application.utils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.salespilot.api.application.exception.InvalidPeriodException;
+
+public class DashboardPeriodUtils {
+
+    public static LocalDateTime[] resolve(String period, LocalDate startDate, LocalDate endDate) {
+        LocalDateTime end = LocalDateTime.now();
+        LocalDateTime start;
+
+        switch (period) {
+            case "30d" ->
+                start = end.minusDays(30);
+            case "90d" ->
+                start = end.minusDays(90);
+            case "custom" -> {
+                if (startDate == null || endDate == null) {
+                    throw new InvalidPeriodException();
+                }
+                start = startDate.atStartOfDay();
+                end = endDate.atTime(23, 59, 59);
+            }
+            default -> throw new InvalidPeriodException();
+        }
+
+        return new LocalDateTime[] { start, end };
+    }
+}

--- a/domain/src/main/java/com/salespilot/api/domain/model/MonthAndTotal.java
+++ b/domain/src/main/java/com/salespilot/api/domain/model/MonthAndTotal.java
@@ -1,8 +1,8 @@
-package com.salespilot.api.application.dto;
+package com.salespilot.api.domain.model;
 
 import java.time.LocalDate;
 
-public record MonthAndTotalDTO(
+public record MonthAndTotal(
     LocalDate month,
     String monthLabel,
     Long total

--- a/domain/src/main/java/com/salespilot/api/domain/repository/MeetingRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/MeetingRepository.java
@@ -1,6 +1,8 @@
 package com.salespilot.api.domain.repository;
 
 import com.salespilot.api.domain.entity.Meeting;
+import com.salespilot.api.domain.model.MonthAndTotal;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -17,5 +19,5 @@ public interface MeetingRepository {
     Optional<Meeting> getMeetingById(UUID id);
     boolean existsById(UUID id);
     Optional<Meeting> getLatestMeetingByCollaborator(UUID CollaboratorId);
-    List<Object[]> getMeetingsGroupedByMonth(LocalDateTime start, LocalDateTime end);
+    List<MonthAndTotal> getMeetingsGroupedByMonth(LocalDateTime start, LocalDateTime end);
 }

--- a/domain/src/main/java/com/salespilot/api/domain/repository/MeetingRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/MeetingRepository.java
@@ -4,6 +4,8 @@ import com.salespilot.api.domain.entity.Meeting;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,4 +17,5 @@ public interface MeetingRepository {
     Optional<Meeting> getMeetingById(UUID id);
     boolean existsById(UUID id);
     Optional<Meeting> getLatestMeetingByCollaborator(UUID CollaboratorId);
+    List<Object[]> getMeetingsGroupedByMonth(LocalDateTime start, LocalDateTime end);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
@@ -14,6 +14,7 @@ import com.salespilot.api.application.usecase.GetAllCompaniesUseCase;
 import com.salespilot.api.application.usecase.GetCompanyByIdUseCase;
 import com.salespilot.api.application.usecase.GetSellerByIdUseCase;
 import com.salespilot.api.application.usecase.GetSystemStatusUseCase;
+import com.salespilot.api.application.usecase.GetTotalMeetingsGroupedByMonthUseCase;
 import com.salespilot.api.application.usecase.PostCompanyUseCase;
 import com.salespilot.api.application.usecase.UpdateCompanyUseCase;
 import com.salespilot.api.application.usecase.GetMeetingContextAndMetadataUseCase;
@@ -105,5 +106,10 @@ public class UseCaseConfig {
     @Bean
     public GetMeetingInsightUseCase getMeetingInsightUseCase(MeetingRealtimeInsightRepository meetingRealtimeInsightRepository, MeetingRepository meetingRepository) {
         return new GetMeetingInsightUseCase(meetingRealtimeInsightRepository, meetingRepository);
+    }
+
+    @Bean
+    public GetTotalMeetingsGroupedByMonthUseCase getTotalMeetingsGroupedByMonthUseCase(MeetingRepository meetingRepository) {
+        return new GetTotalMeetingsGroupedByMonthUseCase(meetingRepository);
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.salespilot.api.infrastructure.persistence.jpa.repository;
 import java.util.UUID;
 
 import com.salespilot.api.domain.entity.Meeting;
+import com.salespilot.api.domain.model.MonthAndTotal;
 import com.salespilot.api.domain.repository.MeetingRepository;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingEntity;
 import com.salespilot.api.infrastructure.persistence.jpa.mapper.MeetingMapper;
@@ -15,8 +16,12 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.TextStyle;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 @Repository
@@ -79,8 +84,37 @@ public class MeetingRepositoryImpl implements MeetingRepository{
         return meetingsJpaRepository.existsById(id);
     }
 
+    @Transactional(readOnly = true)
     @Override
-    public List<Object[]> getMeetingsGroupedByMonth(LocalDateTime start, LocalDateTime end) {
-        return meetingsJpaRepository.getMeetingsGroupedByMonth(start, end);
+    public List<MonthAndTotal> getMeetingsGroupedByMonth(LocalDateTime start, LocalDateTime end) {
+        return meetingsJpaRepository.getMeetingsGroupedByMonth(start, end).stream().map(this::mapToMonthAndTotal).toList();
+    }
+
+    private MonthAndTotal mapToMonthAndTotal(Object[] item) {
+        Object rawMonth = item[0];
+
+        LocalDate month;
+
+        if (rawMonth instanceof Timestamp timestamp) {
+            month = timestamp.toLocalDateTime().toLocalDate();
+        } else if (rawMonth instanceof LocalDateTime localDateTime) {
+            month = localDateTime.toLocalDate();
+        } else if (rawMonth instanceof LocalDate localDate) {
+            month = localDate;
+        } else {
+            throw new IllegalStateException("Tipo inesperado para month: " + rawMonth.getClass());
+        }
+        Long total = ((Number) item[1]).longValue();
+        String monthLabel = month.getMonth().getDisplayName(TextStyle.SHORT, Locale.of("pt", "BR")).replace(".", "");
+
+        return new MonthAndTotal(
+            month,
+            capitalize(monthLabel),
+            total
+        );
+    }
+
+    private String capitalize(String monthLabel) {
+        return monthLabel.substring(0, 1).toUpperCase() + monthLabel.substring(1);
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRepositoryImpl.java
@@ -15,6 +15,8 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -75,5 +77,10 @@ public class MeetingRepositoryImpl implements MeetingRepository{
     @Override
     public boolean existsById(UUID id){
         return meetingsJpaRepository.existsById(id);
+    }
+
+    @Override
+    public List<Object[]> getMeetingsGroupedByMonth(LocalDateTime start, LocalDateTime end) {
+        return meetingsJpaRepository.getMeetingsGroupedByMonth(start, end);
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingsJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingsJpaRepository.java
@@ -2,14 +2,28 @@ package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
 import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingEntity;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MeetingsJpaRepository extends JpaRepository<MeetingEntity, UUID>, JpaSpecificationExecutor<MeetingEntity> {
     @Query("SELECT AVG(m.durationSeconds) FROM MeetingEntity m WHERE m.durationSeconds IS NOT NULL")
     Optional<Double> findAverageDurationSeconds();
+
+    @Query(value = """
+        SELECT
+            DATE_TRUNC('month', created_at) AS month,
+            COUNT(*) AS total
+        FROM meetings
+        WHERE created_at BETWEEN :start AND :end
+        GROUP BY month
+        ORDER BY month ASC
+    """, nativeQuery = true)
+    List<Object[]> getMeetingsGroupedByMonth(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingsJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingsJpaRepository.java
@@ -22,8 +22,8 @@ public interface MeetingsJpaRepository extends JpaRepository<MeetingEntity, UUID
             COUNT(*) AS total
         FROM meetings
         WHERE created_at BETWEEN :start AND :end
-        GROUP BY month
-        ORDER BY month ASC
+        GROUP BY DATE_TRUNC('month', created_at)
+        ORDER BY DATE_TRUNC('month', created_at) ASC
     """, nativeQuery = true)
     List<Object[]> getMeetingsGroupedByMonth(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
@@ -1,0 +1,36 @@
+package com.salespilot.api.presentation.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.salespilot.api.application.dto.MeetingsGroupedByMonthResponseDTO;
+import com.salespilot.api.application.usecase.GetTotalMeetingsGroupedByMonthUseCase;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.time.LocalDate;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+
+@Tag(name = "Dashboard")
+@RestController
+@RequestMapping("/api/dashboard")
+public class DashboardController {
+    private final GetTotalMeetingsGroupedByMonthUseCase getTotalMeetingsGroupedByMonth;
+
+    public DashboardController(GetTotalMeetingsGroupedByMonthUseCase getTotalMeetingsGroupedByMonth){
+        this.getTotalMeetingsGroupedByMonth = getTotalMeetingsGroupedByMonth;
+    }
+
+    @GetMapping("/meetings-by-month")
+    public ResponseEntity<MeetingsGroupedByMonthResponseDTO> getMeetingsGroupedByMonth(
+        @RequestParam(required = false) String period,
+        @RequestParam(required = false) LocalDate start_date,
+        @RequestParam(required = false) LocalDate end_date) {
+        return ResponseEntity.ok(getTotalMeetingsGroupedByMonth.execute(period, start_date, end_date));
+    }
+    
+}

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
@@ -7,6 +7,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.salespilot.api.application.dto.MeetingsGroupedByMonthResponseDTO;
 import com.salespilot.api.application.usecase.GetTotalMeetingsGroupedByMonthUseCase;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.time.LocalDate;
@@ -25,12 +30,26 @@ public class DashboardController {
         this.getTotalMeetingsGroupedByMonth = getTotalMeetingsGroupedByMonth;
     }
 
+    @Operation(summary = "Listar reunoões por mês", description = "Retorna uma lista contendo o mês e sua quantidade de reniões a partir de filtros personalizados, 30d, ou 90d.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso",
+            content = @Content(mediaType = "application/json",
+                    examples = @ExampleObject(value = """
+                            {
+                                "data": [
+                                    { "month": "2024-05-01T00:00:00Z", "month_label": "Mai", "total": 15 },
+                                    { "month": "2024-06-01T00:00:00Z", "month_label": "Jun", "total": 23 }
+                                ]
+                            }
+                            """))),
+        @ApiResponse(responseCode = "400", description = "Parâmetros 'start_date' ou 'end_date' inválidos")
+    })
     @GetMapping("/meetings-by-month")
     public ResponseEntity<MeetingsGroupedByMonthResponseDTO> getMeetingsGroupedByMonth(
-        @RequestParam(required = false) String period,
-        @RequestParam(required = false) LocalDate start_date,
-        @RequestParam(required = false) LocalDate end_date) {
-        return ResponseEntity.ok(getTotalMeetingsGroupedByMonth.execute(period, start_date, end_date));
+        @RequestParam(required = true) String period,
+        @RequestParam(name = "start_date", required = false) LocalDate startDate,
+        @RequestParam(name = "end_date", required = false) LocalDate endDate) {
+        return ResponseEntity.ok(getTotalMeetingsGroupedByMonth.execute(period, startDate, endDate));
     }
     
 }

--- a/presentation/src/main/java/com/salespilot/api/presentation/handler/GlobalExceptionHandler.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import com.salespilot.api.application.exception.MeetingNotFoundException;
 import com.salespilot.api.application.exception.MeetingPostAnalysisNotFoundException;
 import com.salespilot.api.application.exception.TaxIdAlreadyExists;
 import com.salespilot.api.application.exception.InvalidCollaboratorRoleException;
+import com.salespilot.api.application.exception.InvalidPeriodException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -55,5 +56,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InvalidCollaboratorRoleException.class)
     public ResponseEntity<Void> handleInvalidCollaboratorRoleExeption() {
         return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+
+    @ExceptionHandler(InvalidPeriodException.class)
+    public ResponseEntity<Void> handleInvalidPeriodException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     }
 }


### PR DESCRIPTION
## Issue relacionada

https://github.com/SalesPilot-AGES/Backend/issues/42

## O que foi implementado?

Foi criado um endpoint para retornar o número de reuniões a partir de um intervalo de tempo fornecido pelo usuário, últimos 30 dias e 90 dias

## Por que essa mudança é necessária?

Faz parte do previsto para a sprint 3

## Como testar?

Fazer uma requisição GET em http://localhost:8080/api/dashboard/meetings-by-month?period=
o period= pode ser custom&start_date=2024-01-01&end_date=2024-06-30 (data exemplo), 30d ou 90d

## Checklist

- [ X ] O código foi revisado pelo próprio autor antes de abrir o MR
- [ X ] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças