### PR TITLE
feat: success/error messages

### DIFF
--- a/application/src/main/java/com/salespilot/api/application/dto/ApiResponse.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.salespilot.api.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
@@ -10,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * @param <T> O tipo do conteúdo da resposta
  */
 @JsonPropertyOrder({"content", "message"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ApiResponse<T>(
         @JsonProperty("content")
         T content,

--- a/application/src/main/java/com/salespilot/api/application/dto/ApiResponse.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/ApiResponse.java
@@ -1,0 +1,38 @@
+package com.salespilot.api.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * Classe genérica para padronizar as respostas de todos os endpoints.
+ * Encapsula o conteúdo da resposta e uma mensagem amigável para o usuário.
+ *
+ * @param <T> O tipo do conteúdo da resposta
+ */
+@JsonPropertyOrder({"content", "message"})
+public record ApiResponse<T>(
+        @JsonProperty("content")
+        T content,
+        @JsonProperty("message")
+        String message) {
+    /**
+     * Cria uma resposta de sucesso com a mensagem fornecida.
+     *
+     * @param content O conteúdo da resposta
+     * @param message A mensagem de sucesso
+     * @return Uma instância de ApiResponse
+     */
+    public static <T> ApiResponse<T> success(T content, String message) {
+        return new ApiResponse<>(content, message);
+    }
+
+    /**
+     * Cria uma resposta com conteúdo nulo e apenas a mensagem.
+     *
+     * @param message A mensagem
+     * @return Uma instância de ApiResponse com content nulo
+     */
+    public static <T> ApiResponse<T> message(String message) {
+        return new ApiResponse<>(null, message);
+    }
+}

--- a/application/src/main/java/com/salespilot/api/application/dto/MeetingPageResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/MeetingPageResponseDTO.java
@@ -1,21 +1,26 @@
 package com.salespilot.api.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
+@JsonPropertyOrder({"content", "totalElements", "totalPages", "summary", "message"})
 public record MeetingPageResponseDTO(
-        List<MeetingResponseDTO> content,
-        long totalElements,
-        int totalPages,
-        SummaryResponseDTO summary
+        @JsonProperty("content") List<MeetingResponseDTO> content,
+        @JsonProperty("totalElements") long totalElements,
+        @JsonProperty("totalPages") int totalPages,
+        @JsonProperty("summary") SummaryResponseDTO summary,
+        @JsonProperty("message") String message
 ) {
-    public static MeetingPageResponseDTO from(Page<MeetingResponseDTO> page, SummaryResponseDTO summary) {
+    public static MeetingPageResponseDTO from(Page<MeetingResponseDTO> page, SummaryResponseDTO summary, String message) {
         return new MeetingPageResponseDTO(
                 page.getContent(),
                 page.getTotalElements(),
                 page.getTotalPages(),
-                summary
+                summary,
+                message
         );
     }
 }

--- a/application/src/main/java/com/salespilot/api/application/dto/MeetingPageResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/MeetingPageResponseDTO.java
@@ -6,21 +6,19 @@ import org.springframework.data.domain.Page;
 
 import java.util.List;
 
-@JsonPropertyOrder({"content", "totalElements", "totalPages", "summary", "message"})
+@JsonPropertyOrder({"content", "totalElements", "totalPages", "summary"})
 public record MeetingPageResponseDTO(
         @JsonProperty("content") List<MeetingResponseDTO> content,
         @JsonProperty("totalElements") long totalElements,
         @JsonProperty("totalPages") int totalPages,
-        @JsonProperty("summary") SummaryResponseDTO summary,
-        @JsonProperty("message") String message
+        @JsonProperty("summary") SummaryResponseDTO summary
 ) {
-    public static MeetingPageResponseDTO from(Page<MeetingResponseDTO> page, SummaryResponseDTO summary, String message) {
+    public static MeetingPageResponseDTO from(Page<MeetingResponseDTO> page, SummaryResponseDTO summary) {
         return new MeetingPageResponseDTO(
                 page.getContent(),
                 page.getTotalElements(),
                 page.getTotalPages(),
-                summary,
-                message
+                summary
         );
     }
 }

--- a/application/src/main/java/com/salespilot/api/application/dto/PaginatedResponse.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/PaginatedResponse.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
-@JsonPropertyOrder({"content", "empty", "first", "last", "number", "numberOfElements", "pageable", "size", "sort", "totalElements", "totalPages", "message"})
+@JsonPropertyOrder({"content", "empty", "first", "last", "number", "numberOfElements", "pageable", "size", "sort", "totalElements", "totalPages"})
 public record PaginatedResponse<T>(
     @JsonProperty("content") List<T> content,
     @JsonProperty("empty") boolean empty,
@@ -20,10 +20,9 @@ public record PaginatedResponse<T>(
     @JsonProperty("size") int size,
     @JsonProperty("sort") Sort sort,
     @JsonProperty("totalElements") long totalElements,
-    @JsonProperty("totalPages") int totalPages,
-    @JsonProperty("message") String message
+    @JsonProperty("totalPages") int totalPages
 ) {
-    public static <T> PaginatedResponse<T> from(Page<T> page, String message) {
+    public static <T> PaginatedResponse<T> from(Page<T> page) {
         return new PaginatedResponse<>(
             page.getContent(),
             page.isEmpty(),
@@ -35,8 +34,7 @@ public record PaginatedResponse<T>(
             page.getSize(),
             page.getSort(),
             page.getTotalElements(),
-            page.getTotalPages(),
-            message
+            page.getTotalPages()
         );
     }
 }

--- a/application/src/main/java/com/salespilot/api/application/dto/PaginatedResponse.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/PaginatedResponse.java
@@ -1,0 +1,42 @@
+package com.salespilot.api.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+@JsonPropertyOrder({"content", "empty", "first", "last", "number", "numberOfElements", "pageable", "size", "sort", "totalElements", "totalPages", "message"})
+public record PaginatedResponse<T>(
+    @JsonProperty("content") List<T> content,
+    @JsonProperty("empty") boolean empty,
+    @JsonProperty("first") boolean first,
+    @JsonProperty("last") boolean last,
+    @JsonProperty("number") int number,
+    @JsonProperty("numberOfElements") int numberOfElements,
+    @JsonProperty("pageable") Pageable pageable,
+    @JsonProperty("size") int size,
+    @JsonProperty("sort") Sort sort,
+    @JsonProperty("totalElements") long totalElements,
+    @JsonProperty("totalPages") int totalPages,
+    @JsonProperty("message") String message
+) {
+    public static <T> PaginatedResponse<T> from(Page<T> page, String message) {
+        return new PaginatedResponse<>(
+            page.getContent(),
+            page.isEmpty(),
+            page.isFirst(),
+            page.isLast(),
+            page.getNumber(),
+            page.getNumberOfElements(),
+            page.getPageable(),
+            page.getSize(),
+            page.getSort(),
+            page.getTotalElements(),
+            page.getTotalPages(),
+            message
+        );
+    }
+}

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetAllMeetingsUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetAllMeetingsUseCase.java
@@ -56,6 +56,6 @@ public class GetAllMeetingsUseCase {
                 repository.getTotalMeetings(),
                 repository.getAverageDurationSeconds(),
                 meetingPostAnalysisRepository.getAverageSuccessRate()
-        ));
+        ), "Reuniões listadas com sucesso");
     }
 }

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetAllMeetingsUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetAllMeetingsUseCase.java
@@ -56,6 +56,6 @@ public class GetAllMeetingsUseCase {
                 repository.getTotalMeetings(),
                 repository.getAverageDurationSeconds(),
                 meetingPostAnalysisRepository.getAverageSuccessRate()
-        ), "Reuniões listadas com sucesso");
+        ));
     }
 }

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/CollaboratorController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/CollaboratorController.java
@@ -1,8 +1,10 @@
 package com.salespilot.api.presentation.controller;
 
+import com.salespilot.api.application.dto.ApiResponse;
 import com.salespilot.api.application.dto.CollaboratorResponseDTO;
 import com.salespilot.api.application.dto.SellerResponseDTO;
 import com.salespilot.api.application.dto.SellerWithMeetingsResponseDTO;
+import com.salespilot.api.application.dto.PaginatedResponse;
 import com.salespilot.api.application.usecase.EditCollaboratorUseCase;
 import com.salespilot.api.application.usecase.GetAllManagersUseCase;
 import com.salespilot.api.application.usecase.GetAllSellersUseCase;
@@ -17,7 +19,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -42,244 +43,249 @@ import java.util.UUID;
 @RequestMapping("/api/collaborators")
 public class CollaboratorController {
 
-    private final PostCollaboratorUseCase postCollaboratorUseCase;
-    private final EditCollaboratorUseCase editCollaboratorUseCase;
-    private final GetCollaboratorByIdUseCase getCollaboratorByIdUseCase;
-    private final GetAllManagersUseCase getAllManagersUseCase;
-    private final GetAllSellersUseCase getAllSellersUseCase;
-    private final GetSellerByIdUseCase getSellerByIdUseCase;
+        private final PostCollaboratorUseCase postCollaboratorUseCase;
+        private final EditCollaboratorUseCase editCollaboratorUseCase;
+        private final GetCollaboratorByIdUseCase getCollaboratorByIdUseCase;
+        private final GetAllManagersUseCase getAllManagersUseCase;
+        private final GetAllSellersUseCase getAllSellersUseCase;
+        private final GetSellerByIdUseCase getSellerByIdUseCase;
 
-    private static final String COLLABORATOR_REQUEST_EXAMPLE = """
-            {
-              "company_id": "b1c2d3e4-f5a6-7890-2345-67890abcdef1",
-              "name": "Gabriel Ribeiro",
-              "email": "gabriel@digitalsales.com",
-              "phone": "+55 (11) 98888-7777",
-              "active": true,
-              "preferences": {
-                "theme": "light",
-                "default_model": "gpt-4o"
-              }
-            }
-            """;
+        private static final String COLLABORATOR_REQUEST_EXAMPLE = """
+                        {
+                          "company_id": "b1c2d3e4-f5a6-7890-2345-67890abcdef1",
+                          "name": "Gabriel Ribeiro",
+                          "email": "gabriel@digitalsales.com",
+                          "phone": "+55 (11) 98888-7777",
+                          "active": true,
+                          "preferences": {
+                            "theme": "light",
+                            "default_model": "gpt-4o"
+                          }
+                        }
+                        """;
 
-    private static final String MANAGER_RESPONSE_EXAMPLE = """
-            {
-              "id": "c3d4e5f6-a7b8-9012-3456-7890abcdef12",
-              "company_id": "b1c2d3e4-f5a6-7890-2345-67890abcdef1",
-              "name": "Gabriel Ribeiro",
-              "role": "MANAGER",
-              "email": "gabriel@digitalsales.com",
-              "active": true,
-              "preferences": {
-                "theme": "light",
-                "default_model": "gpt-4o"
-              },
-              "average_feeling": 0,
-              "created_at": "2024-04-02T10:01:00",
-              "company": {
-                "id": "b1c2d3e4-f5a6-7890-2345-67890abcdef1",
-                "name": "Digital Sales",
-                "tax_id": "12.345.678/0001-90",
-                "active": true,
-                "created_at": "2024-04-01T08:00:00",
-                "updated_at": "2024-04-01T08:00:00",
-                "plan": "PRO"
-              }
-            }
-            """;
+        private static final String MANAGER_RESPONSE_EXAMPLE = """
+                        {
+                          "id": "c3d4e5f6-a7b8-9012-3456-7890abcdef12",
+                          "company_id": "b1c2d3e4-f5a6-7890-2345-67890abcdef1",
+                          "name": "Gabriel Ribeiro",
+                          "role": "MANAGER",
+                          "email": "gabriel@digitalsales.com",
+                          "active": true,
+                          "preferences": {
+                            "theme": "light",
+                            "default_model": "gpt-4o"
+                          },
+                          "average_feeling": 0,
+                          "created_at": "2024-04-02T10:01:00",
+                          "company": {
+                            "id": "b1c2d3e4-f5a6-7890-2345-67890abcdef1",
+                            "name": "Digital Sales",
+                            "tax_id": "12.345.678/0001-90",
+                            "active": true,
+                            "created_at": "2024-04-01T08:00:00",
+                            "updated_at": "2024-04-01T08:00:00",
+                            "plan": "PRO"
+                          }
+                        }
+                        """;
 
         private static final String SELLER_RESPONSE_EXAMPLE = """
-            {
-              "id": "c3d4e5f6-a7b8-9012-3456-7890abcdef12",
-              "company_id": "b1c2d3e4-f5a6-7890-2345-67890abcdef1",
-              "name": "Gabriel Ribeiro",
-              "role": "SELLER",
-              "email": "gabriel@digitalsales.com",
-              "phone": "+55 (11) 98888-7777",
-              "active": true,
-              "preferences": {
-                "theme": "light",
-                "default_model": "gpt-4o"
-              },
-              "average_feeling": 0,
-              "totalMeetings": 0,
-              "created_at": "2024-04-02T10:01:00",
-              "company": {
-                "id": "b1c2d3e4-f5a6-7890-2345-67890abcdef1",
-                "name": "Digital Sales",
-                "tax_id": "12.345.678/0001-90",
-                "active": true,
-                "created_at": "2024-04-01T08:00:00",
-                "updated_at": "2024-04-01T08:00:00",
-                "plan": "PRO"
-              }
-            }
-            """;
+                        {
+                          "id": "c3d4e5f6-a7b8-9012-3456-7890abcdef12",
+                          "company_id": "b1c2d3e4-f5a6-7890-2345-67890abcdef1",
+                          "name": "Gabriel Ribeiro",
+                          "role": "SELLER",
+                          "email": "gabriel@digitalsales.com",
+                          "phone": "+55 (11) 98888-7777",
+                          "active": true,
+                          "preferences": {
+                            "theme": "light",
+                            "default_model": "gpt-4o"
+                          },
+                          "average_feeling": 0,
+                          "totalMeetings": 0,
+                          "created_at": "2024-04-02T10:01:00",
+                          "company": {
+                            "id": "b1c2d3e4-f5a6-7890-2345-67890abcdef1",
+                            "name": "Digital Sales",
+                            "tax_id": "12.345.678/0001-90",
+                            "active": true,
+                            "created_at": "2024-04-01T08:00:00",
+                            "updated_at": "2024-04-01T08:00:00",
+                            "plan": "PRO"
+                          }
+                        }
+                        """;
 
-    public CollaboratorController(PostCollaboratorUseCase postCollaboratorUseCase,
-            EditCollaboratorUseCase editCollaboratorUseCase,
-            GetCollaboratorByIdUseCase getCollaboratorByIdUseCase,
-            GetAllManagersUseCase getAllManagersUseCase,
-            GetAllSellersUseCase getAllSellersUseCase,
-            GetSellerByIdUseCase getSellerByIdUseCase) {
-        this.postCollaboratorUseCase = postCollaboratorUseCase;
-        this.editCollaboratorUseCase = editCollaboratorUseCase;
-        this.getCollaboratorByIdUseCase = getCollaboratorByIdUseCase;
-        this.getAllManagersUseCase = getAllManagersUseCase;
-        this.getAllSellersUseCase = getAllSellersUseCase;
-        this.getSellerByIdUseCase = getSellerByIdUseCase;
-    }
-
-    @Operation(summary = "Cadastrar manager", description = "Cria um novo colaborador com o papel de MANAGER.")
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Manager criado com sucesso", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = MANAGER_RESPONSE_EXAMPLE))),
-            @ApiResponse(responseCode = "404", description = "Empresa não encontrada", content = @Content),
-            @ApiResponse(responseCode = "409", description = "Colaborador já existe nesta empresa com este e-mail", content = @Content),
-            @ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
-    })
-    @PostMapping("/managers")
-    public ResponseEntity<CollaboratorResponseDTO> createManager(
-            @Valid @RequestBody CollaboratorRequestDTO request) {
-        CollaboratorResponseDTO response = postCollaboratorUseCase.create(
-                request.companyId(),
-                request.name(),
-                request.email(),
-                CollaboratorRole.MANAGER,
-                request.active(),
-                request.phone(),
-                request.preferences(),
-                0);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
-    }
-
-    @Operation(summary = "Editar manager", description = "Atualiza os dados de um colaborador com papel de MANAGER.")
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorUpdateRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Manager atualizado com sucesso", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = MANAGER_RESPONSE_EXAMPLE))),
-            @ApiResponse(responseCode = "404", description = "Manager não encontrado", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Empresa não encontrada", content = @Content),
-            @ApiResponse(responseCode = "409", description = "Role inválida", content = @Content),
-            @ApiResponse(responseCode = "409", description = "Colaborador já existe nesta empresa com este e-mail", content = @Content),
-            @ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
-    })
-    @PutMapping("/managers/{id}")
-    public ResponseEntity<CollaboratorResponseDTO> editCollaborator(
-            @Parameter(description = "UUID do manager") @PathVariable UUID id,
-            @Valid @RequestBody CollaboratorUpdateRequestDTO request) {
-        CollaboratorResponseDTO response = editCollaboratorUseCase.execute(
-                request.companyId(),
-                id,
-                request.name(),
-                request.email(),
-                request.phone(),
-                request.active(),
-                request.preferences(),
-                CollaboratorRole.MANAGER);
-
-        return ResponseEntity.status(HttpStatus.OK).body(response);
-    }
-
-    @Operation(summary = "Buscar manager por ID", description = "Retorna os dados de um manager pelo seu UUID.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Manager encontrado", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = MANAGER_RESPONSE_EXAMPLE))),
-            @ApiResponse(responseCode = "404", description = "Manager não encontrado", content = @Content),                        
-            @ApiResponse(responseCode = "409", description = "Role inválida", content = @Content)
-    })
-    @GetMapping("/managers/{id}")
-    public ResponseEntity<CollaboratorResponseDTO> getManagerById(
-            @Parameter(description = "UUID do manager") @PathVariable UUID id) {
-        CollaboratorResponseDTO collaboratorResponseDTO = getCollaboratorByIdUseCase.execute(id);
-        return ResponseEntity.ok(collaboratorResponseDTO);
-    }
-
-    @GetMapping("/managers")
-    public ResponseEntity<Page<CollaboratorResponseDTO>> getManagers(
-            @RequestParam(required = false) String name,
-            @RequestParam(required = false) String email,
-            @RequestParam(required = false) UUID companyId,
-            @RequestParam(required = false) Boolean active,
-            Pageable pageable) {
-        return ResponseEntity
-                .ok(getAllManagersUseCase.execute(name, email, companyId, active, PageableUtils.normalize(pageable)));
-    }
-
-    @Operation(summary = "Buscar sellers", description = "Retorna todos os sellers, a partir de um filtro ou não.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Sellers encontrados", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SellerResponseDTO.class), examples = @ExampleObject(value = SELLER_RESPONSE_EXAMPLE))),
-            @ApiResponse(responseCode = "404", description = "Seller não encontrado", content = @Content)
-    })
-    @GetMapping("/sellers")
-    public ResponseEntity<Page<SellerResponseDTO>> getSellers(
-            @Parameter(description = "Filtro por nome (contendo)") @RequestParam(required = false) String name,
-            @Parameter(description = "Filtro por email (exato)") @RequestParam(required = false) String email,
-            @Parameter(description = "Filtro por companyId") @RequestParam(required = false) UUID companyId,
-            @Parameter(description = "Filtro por status (ativo ou inativo") @RequestParam(required = false) Boolean active,
-            @Parameter(description = "Paginação e ordenação") Pageable pageable) {
-        return ResponseEntity
-                .ok(getAllSellersUseCase.execute(name, email, companyId, active, PageableUtils.normalize(pageable)));
+        public CollaboratorController(PostCollaboratorUseCase postCollaboratorUseCase,
+                        EditCollaboratorUseCase editCollaboratorUseCase,
+                        GetCollaboratorByIdUseCase getCollaboratorByIdUseCase,
+                        GetAllManagersUseCase getAllManagersUseCase,
+                        GetAllSellersUseCase getAllSellersUseCase,
+                        GetSellerByIdUseCase getSellerByIdUseCase) {
+                this.postCollaboratorUseCase = postCollaboratorUseCase;
+                this.editCollaboratorUseCase = editCollaboratorUseCase;
+                this.getCollaboratorByIdUseCase = getCollaboratorByIdUseCase;
+                this.getAllManagersUseCase = getAllManagersUseCase;
+                this.getAllSellersUseCase = getAllSellersUseCase;
+                this.getSellerByIdUseCase = getSellerByIdUseCase;
         }
-        
-        
-    @Operation(summary = "Cadastrar seller", description = "Cria um novo colaborador com o papel de SELLER.")
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Seller criado com sucesso", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = SELLER_RESPONSE_EXAMPLE))),
-            @ApiResponse(responseCode = "404", description = "Empresa não encontrada", content = @Content),
-            @ApiResponse(responseCode = "409", description = "Colaborador já existe nesta empresa com este e-mail", content = @Content),
-            @ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
-    })
-    @PostMapping("/sellers")
-    public ResponseEntity<CollaboratorResponseDTO> createSeller(
-            @Valid @RequestBody CollaboratorRequestDTO request) {
-        CollaboratorResponseDTO response = postCollaboratorUseCase.create(
-                request.companyId(),
-                request.name(),
-                request.email(),
-                CollaboratorRole.SELLER,
-                request.active(),
-                request.phone(),
-                request.preferences(),
-                0);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
-    }
-    
-    @Operation(summary = "Editar seller", description = "Atualiza os dados de um colaborador com papel de SELLER.")
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorUpdateRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Seller atualizado com sucesso", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = SELLER_RESPONSE_EXAMPLE))),
-            @ApiResponse(responseCode = "404", description = "Seller não encontrado", content = @Content),
-            @ApiResponse(responseCode = "409", description = "Colaborador já existe nesta empresa com este e-mail", content = @Content),
-            @ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
-    })
-    @PutMapping("/sellers/{id}")
-    public ResponseEntity<CollaboratorResponseDTO> editSeller(
-            @Parameter(description = "UUID do seller") @PathVariable UUID id,
-            @Valid @RequestBody CollaboratorUpdateRequestDTO request) {
-        CollaboratorResponseDTO response = editCollaboratorUseCase.execute(
-                request.companyId(),
-                id,
-                request.name(),
-                request.email(),
-                request.phone(),
-                request.active(),
-                request.preferences(),
-                CollaboratorRole.SELLER);
 
-        return ResponseEntity.status(HttpStatus.OK).body(response);
-    }
+        @Operation(summary = "Cadastrar manager", description = "Cria um novo colaborador com o papel de MANAGER.")
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Gestor criado com sucesso", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = MANAGER_RESPONSE_EXAMPLE))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Empresa não encontrada", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Colaborador já existe nesta empresa com este e-mail", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
+        })
+        @PostMapping("/managers")
+        public ResponseEntity<ApiResponse<CollaboratorResponseDTO>> createManager(
+                        @Valid @RequestBody CollaboratorRequestDTO request) {
+                CollaboratorResponseDTO response = postCollaboratorUseCase.create(
+                                request.companyId(),
+                                request.name(),
+                                request.email(),
+                                CollaboratorRole.MANAGER,
+                                request.active(),
+                                request.phone(),
+                                request.preferences(),
+                                0);
+                return ResponseEntity.status(HttpStatus.CREATED)
+                                .body(ApiResponse.success(response, "Gestor criado com sucesso"));
+        }
 
-    @Operation(summary = "Buscar seller por ID", description = "Retorna os dados de um seller pelo seu UUID.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Seller encontrado", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SellerWithMeetingsResponseDTO.class))),
-            @ApiResponse(responseCode = "404", description = "Seller não encontrado", content = @Content),
-            @ApiResponse(responseCode = "409", description = "Role inválida", content = @Content),
-    })
-    @GetMapping("/sellers/{id}")
-    public ResponseEntity<SellerWithMeetingsResponseDTO> getSellerById(
-                @Parameter(description = "UUID do vendedor") @PathVariable UUID id) {
-        SellerWithMeetingsResponseDTO sellerWithMeetingsResponseDTO = getSellerByIdUseCase.execute(id);
-        return ResponseEntity.ok(sellerWithMeetingsResponseDTO);
-    }
+        @Operation(summary = "Editar manager", description = "Atualiza os dados de um colaborador com papel de MANAGER.")
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorUpdateRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Gestor atualizado com sucesso", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = MANAGER_RESPONSE_EXAMPLE))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Gestor não encontrado", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Empresa não encontrada", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Role inválida", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Colaborador já existe nesta empresa com este e-mail", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
+        })
+        @PutMapping("/managers/{id}")
+        public ResponseEntity<ApiResponse<CollaboratorResponseDTO>> editCollaborator(
+                        @Parameter(description = "UUID do manager") @PathVariable UUID id,
+                        @Valid @RequestBody CollaboratorUpdateRequestDTO request) {
+                CollaboratorResponseDTO response = editCollaboratorUseCase.execute(
+                                request.companyId(),
+                                id,
+                                request.name(),
+                                request.email(),
+                                request.phone(),
+                                request.active(),
+                                request.preferences(),
+                                CollaboratorRole.MANAGER);
+
+                return ResponseEntity.status(HttpStatus.OK)
+                                .body(ApiResponse.success(response, "Gestor atualizado com sucesso"));
+        }
+
+        @Operation(summary = "Buscar manager por ID", description = "Retorna os dados de um manager pelo seu UUID.")
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Manager encontrado", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = MANAGER_RESPONSE_EXAMPLE))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Manager não encontrado", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Role inválida", content = @Content)
+        })
+        @GetMapping("/managers/{id}")
+        public ResponseEntity<ApiResponse<CollaboratorResponseDTO>> getManagerById(
+                        @Parameter(description = "UUID do manager") @PathVariable UUID id) {
+                CollaboratorResponseDTO collaboratorResponseDTO = getCollaboratorByIdUseCase.execute(id);
+                return ResponseEntity.ok(ApiResponse.success(collaboratorResponseDTO, "Manager encontrado"));
+        }
+
+        @GetMapping("/managers")
+        public ResponseEntity<PaginatedResponse<CollaboratorResponseDTO>> getManagers(
+                        @RequestParam(required = false) String name,
+                        @RequestParam(required = false) String email,
+                        @RequestParam(required = false) UUID companyId,
+                        @RequestParam(required = false) Boolean active,
+                        Pageable pageable) {
+                Page<CollaboratorResponseDTO> managers = getAllManagersUseCase.execute(name, email, companyId, active,
+                                PageableUtils.normalize(pageable));
+                return ResponseEntity.ok(PaginatedResponse.from(managers, "Gestores listados com sucesso"));
+        }
+
+        @Operation(summary = "Buscar sellers", description = "Retorna todos os sellers, a partir de um filtro ou não.")
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Sellers encontrados", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SellerResponseDTO.class), examples = @ExampleObject(value = SELLER_RESPONSE_EXAMPLE))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Seller não encontrado", content = @Content)
+        })
+        @GetMapping("/sellers")
+        public ResponseEntity<PaginatedResponse<SellerResponseDTO>> getSellers(
+                        @Parameter(description = "Filtro por nome (contendo)") @RequestParam(required = false) String name,
+                        @Parameter(description = "Filtro por email (exato)") @RequestParam(required = false) String email,
+                        @Parameter(description = "Filtro por companyId") @RequestParam(required = false) UUID companyId,
+                        @Parameter(description = "Filtro por status (ativo ou inativo") @RequestParam(required = false) Boolean active,
+                        @Parameter(description = "Paginação e ordenação") Pageable pageable) {
+                Page<SellerResponseDTO> sellers = getAllSellersUseCase.execute(name, email, companyId, active,
+                                PageableUtils.normalize(pageable));
+                return ResponseEntity.ok(PaginatedResponse.from(sellers, "Vendedores listados com sucesso"));
+        }
+
+        @Operation(summary = "Cadastrar seller", description = "Cria um novo colaborador com o papel de SELLER.")
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Seller criado com sucesso", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = SELLER_RESPONSE_EXAMPLE))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Empresa não encontrada", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Colaborador já existe nesta empresa com este e-mail", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
+        })
+        @PostMapping("/sellers")
+        public ResponseEntity<ApiResponse<CollaboratorResponseDTO>> createSeller(
+                        @Valid @RequestBody CollaboratorRequestDTO request) {
+                CollaboratorResponseDTO response = postCollaboratorUseCase.create(
+                                request.companyId(),
+                                request.name(),
+                                request.email(),
+                                CollaboratorRole.SELLER,
+                                request.active(),
+                                request.phone(),
+                                request.preferences(),
+                                0);
+                return ResponseEntity.status(HttpStatus.CREATED)
+                                .body(ApiResponse.success(response, "Vendedor criado com sucesso"));
+        }
+
+        @Operation(summary = "Editar seller", description = "Atualiza os dados de um colaborador com papel de SELLER.")
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorUpdateRequestDTO.class), examples = @ExampleObject(value = COLLABORATOR_REQUEST_EXAMPLE)))
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendedor atualizado com sucesso", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CollaboratorResponseDTO.class), examples = @ExampleObject(value = SELLER_RESPONSE_EXAMPLE))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Vendedor não encontrado", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Colaborador já existe nesta empresa com este e-mail", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
+        })
+        @PutMapping("/sellers/{id}")
+        public ResponseEntity<ApiResponse<CollaboratorResponseDTO>> editSeller(
+                        @Parameter(description = "UUID do seller") @PathVariable UUID id,
+                        @Valid @RequestBody CollaboratorUpdateRequestDTO request) {
+                CollaboratorResponseDTO response = editCollaboratorUseCase.execute(
+                                request.companyId(),
+                                id,
+                                request.name(),
+                                request.email(),
+                                request.phone(),
+                                request.active(),
+                                request.preferences(),
+                                CollaboratorRole.SELLER);
+
+                return ResponseEntity.status(HttpStatus.OK)
+                                .body(ApiResponse.success(response, "Vendedor atualizado com sucesso"));
+        }
+
+        @Operation(summary = "Buscar vendedor por ID", description = "Retorna os dados de um vendedor pelo seu UUID.")
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Vendedor encontrado", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SellerWithMeetingsResponseDTO.class))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Vendedor não encontrado", content = @Content),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Role inválida", content = @Content),
+        })
+        @GetMapping("/sellers/{id}")
+        public ResponseEntity<ApiResponse<SellerWithMeetingsResponseDTO>> getSellerById(
+                        @Parameter(description = "UUID do vendedor") @PathVariable UUID id) {
+                SellerWithMeetingsResponseDTO sellerWithMeetingsResponseDTO = getSellerByIdUseCase.execute(id);
+                return ResponseEntity.ok(ApiResponse.success(sellerWithMeetingsResponseDTO, "Vendedor encontrado"));
+        }
 }

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/CollaboratorController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/CollaboratorController.java
@@ -198,7 +198,7 @@ public class CollaboratorController {
         }
 
         @GetMapping("/managers")
-        public ResponseEntity<PaginatedResponse<CollaboratorResponseDTO>> getManagers(
+        public ResponseEntity<ApiResponse<PaginatedResponse<CollaboratorResponseDTO>>> getManagers(
                         @RequestParam(required = false) String name,
                         @RequestParam(required = false) String email,
                         @RequestParam(required = false) UUID companyId,
@@ -206,7 +206,7 @@ public class CollaboratorController {
                         Pageable pageable) {
                 Page<CollaboratorResponseDTO> managers = getAllManagersUseCase.execute(name, email, companyId, active,
                                 PageableUtils.normalize(pageable));
-                return ResponseEntity.ok(PaginatedResponse.from(managers, "Gestores listados com sucesso"));
+                return ResponseEntity.ok(ApiResponse.success(PaginatedResponse.from(managers), "Gestores listados com sucesso"));
         }
 
         @Operation(summary = "Buscar sellers", description = "Retorna todos os sellers, a partir de um filtro ou não.")
@@ -215,7 +215,7 @@ public class CollaboratorController {
                         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Seller não encontrado", content = @Content)
         })
         @GetMapping("/sellers")
-        public ResponseEntity<PaginatedResponse<SellerResponseDTO>> getSellers(
+        public ResponseEntity<ApiResponse<PaginatedResponse<SellerResponseDTO>>> getSellers(
                         @Parameter(description = "Filtro por nome (contendo)") @RequestParam(required = false) String name,
                         @Parameter(description = "Filtro por email (exato)") @RequestParam(required = false) String email,
                         @Parameter(description = "Filtro por companyId") @RequestParam(required = false) UUID companyId,
@@ -223,7 +223,7 @@ public class CollaboratorController {
                         @Parameter(description = "Paginação e ordenação") Pageable pageable) {
                 Page<SellerResponseDTO> sellers = getAllSellersUseCase.execute(name, email, companyId, active,
                                 PageableUtils.normalize(pageable));
-                return ResponseEntity.ok(PaginatedResponse.from(sellers, "Vendedores listados com sucesso"));
+                return ResponseEntity.ok(ApiResponse.success(PaginatedResponse.from(sellers), "Vendedores listados com sucesso"));
         }
 
         @Operation(summary = "Cadastrar seller", description = "Cria um novo colaborador com o papel de SELLER.")

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/CompanyController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/CompanyController.java
@@ -1,6 +1,8 @@
 package com.salespilot.api.presentation.controller;
 
+import com.salespilot.api.application.dto.ApiResponse;
 import com.salespilot.api.application.dto.CompanyResponseDTO;
+import com.salespilot.api.application.dto.PaginatedResponse;
 import com.salespilot.api.application.usecase.GetAllCompaniesUseCase;
 import com.salespilot.api.application.usecase.GetCompanyByIdUseCase;
 import com.salespilot.api.application.usecase.PostCompanyUseCase;
@@ -12,7 +14,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -80,32 +81,32 @@ public class CompanyController {
                     }
                     """)))
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Empresa criada com sucesso",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Empresa criada com sucesso",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CompanyResponseDTO.class),
                             examples = @ExampleObject(value = COMPANY_RESPONSE_EXAMPLE))),
-            @ApiResponse(responseCode = "409", description = "CNPJ já cadastrado", content = @Content),
-            @ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "CNPJ já cadastrado", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
     })
     @PostMapping
-    public ResponseEntity<CompanyResponseDTO> create(@Valid @RequestBody CompanyRequestDTO request) {
+    public ResponseEntity<ApiResponse<CompanyResponseDTO>> create(@Valid @RequestBody CompanyRequestDTO request) {
         CompanyResponseDTO response = postCompanyUseCase.create(request.name(), request.taxId(), request.plan(), request.active());
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "Empresa criada com sucesso"));
     }
 
     @Operation(summary = "Buscar empresa por ID", description = "Retorna os dados de uma empresa pelo seu UUID.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Empresa encontrada",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Empresa encontrada",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CompanyResponseDTO.class),
                             examples = @ExampleObject(value = COMPANY_RESPONSE_EXAMPLE))),
-            @ApiResponse(responseCode = "404", description = "Empresa não encontrada", content = @Content)
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Empresa não encontrada", content = @Content)
     })
     @GetMapping("/{id}")
-    public ResponseEntity<CompanyResponseDTO> getCompanyById(
+    public ResponseEntity<ApiResponse<CompanyResponseDTO>> getCompanyById(
             @Parameter(description = "UUID da empresa") @PathVariable UUID id) {
         return getCompanyByIdUseCase.execute(id)
-                .map(ResponseEntity::ok)
+                .map(company -> ResponseEntity.ok(ApiResponse.success(company, "Empresa encontrada")))
                 .orElse(ResponseEntity.notFound().build());
     }
 
@@ -121,23 +122,23 @@ public class CompanyController {
                     }
                     """)))
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Empresa atualizada",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Empresa atualizada",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CompanyResponseDTO.class),
                             examples = @ExampleObject(value = COMPANY_RESPONSE_EXAMPLE))),
-            @ApiResponse(responseCode = "404", description = "Empresa não encontrada", content = @Content),
-            @ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Empresa não encontrada", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Dados inválidos", content = @Content)
     })
     @PutMapping("/{id}")
-    public ResponseEntity<CompanyResponseDTO> updateCompany(
+    public ResponseEntity<ApiResponse<CompanyResponseDTO>> updateCompany(
             @Parameter(description = "UUID da empresa") @PathVariable UUID id,
             @Valid @RequestBody UpdateCompanyRequestDTO request) {
         CompanyResponseDTO company = updateCompanyUseCase.execute(id, request.name(), request.plan(), request.active());
-        return ResponseEntity.ok(company);
+        return ResponseEntity.ok(ApiResponse.success(company, "Empresa atualizada com sucesso"));
     }
 
     @Operation(summary = "Listar empresas", description = "Retorna uma página de empresas com filtros opcionais.")
-    @ApiResponse(responseCode = "200", description = "Lista paginada de empresas",
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Lista paginada de empresas",
             content = @Content(mediaType = "application/json",
                     examples = @ExampleObject(value = """
                             {
@@ -162,14 +163,15 @@ public class CompanyController {
                             }
                             """)))
     @GetMapping
-    public ResponseEntity<Page<CompanyResponseDTO>> getAll(
+    public ResponseEntity<PaginatedResponse<CompanyResponseDTO>> getAll(
             @Parameter(description = "Filtro por nome (parcial)") @RequestParam(required = false) String name,
             @Parameter(description = "Filtro por CNPJ (exato)") @RequestParam(required = false) String taxId,
             @Parameter(description = "Filtro por plano", example = "BASIC") @RequestParam(required = false) String plan,
             @Parameter(description = "Filtro por status de ativação") @RequestParam(required = false) Boolean active,
             Pageable pageable) {
         Pageable safePageable = normalizePageable(pageable);
-        return ResponseEntity.ok(getCompanyUseCase.execute(name, taxId, plan, active, safePageable));
+        Page<CompanyResponseDTO> companies = getCompanyUseCase.execute(name, taxId, plan, active, safePageable);
+        return ResponseEntity.ok(PaginatedResponse.from(companies, "Empresas listadas com sucesso"));
     }
 
     private Pageable normalizePageable(Pageable pageable) {

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/CompanyController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/CompanyController.java
@@ -163,7 +163,7 @@ public class CompanyController {
                             }
                             """)))
     @GetMapping
-    public ResponseEntity<PaginatedResponse<CompanyResponseDTO>> getAll(
+    public ResponseEntity<ApiResponse<PaginatedResponse<CompanyResponseDTO>>> getAll(
             @Parameter(description = "Filtro por nome (parcial)") @RequestParam(required = false) String name,
             @Parameter(description = "Filtro por CNPJ (exato)") @RequestParam(required = false) String taxId,
             @Parameter(description = "Filtro por plano", example = "BASIC") @RequestParam(required = false) String plan,
@@ -171,7 +171,7 @@ public class CompanyController {
             Pageable pageable) {
         Pageable safePageable = normalizePageable(pageable);
         Page<CompanyResponseDTO> companies = getCompanyUseCase.execute(name, taxId, plan, active, safePageable);
-        return ResponseEntity.ok(PaginatedResponse.from(companies, "Empresas listadas com sucesso"));
+        return ResponseEntity.ok(ApiResponse.success(PaginatedResponse.from(companies), "Empresas listadas com sucesso"));
     }
 
     private Pageable normalizePageable(Pageable pageable) {

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
@@ -1,5 +1,6 @@
 package com.salespilot.api.presentation.controller;
 
+import com.salespilot.api.application.dto.ApiResponse;
 import com.salespilot.api.application.dto.MeetingContextMetadataResponseDTO;
 import com.salespilot.api.application.dto.MeetingPageResponseDTO;
 import com.salespilot.api.application.dto.MeetingPostAnalysisResponseDTO;
@@ -14,7 +15,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -47,7 +47,7 @@ public class MeetingController {
 
     @Operation(summary = "Listar reuniões", description = "Retorna uma página de reuniões com filtros opcionais e métricas gerais.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Reuniões retornadas com sucesso",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Reuniões retornadas com sucesso",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = MeetingPageResponseDTO.class),
                             examples = @ExampleObject(value = """
@@ -92,12 +92,20 @@ public class MeetingController {
             @Parameter(description = "Filtrar por empresa do cliente (parcial)") @RequestParam(required = false) String clientCompanyName,
             @Parameter(description = "Filtrar por ID do vendedor") @RequestParam(required = false) UUID collaboratorId,
             Pageable pageable) {
-        return ResponseEntity.ok(getAllMeetingsUseCase.execute(title, clientCompanyName, collaboratorId, PageableUtils.normalize(pageable)));
+        MeetingPageResponseDTO meetings = getAllMeetingsUseCase.execute(title, clientCompanyName, collaboratorId, PageableUtils.normalize(pageable));
+        MeetingPageResponseDTO meetingsWithMessage = new MeetingPageResponseDTO(
+                meetings.content(),
+                meetings.totalElements(),
+                meetings.totalPages(),
+                meetings.summary(),
+                "Reuniões listadas com sucesso"
+        );
+        return ResponseEntity.ok(meetingsWithMessage);
     }
 
     @Operation(summary = "Buscar reunião por ID", description = "Retorna os dados completos de contexto e metadados de uma reunião.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Reunião encontrada",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Reunião encontrada",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = MeetingContextMetadataResponseDTO.class),
                             examples = @ExampleObject(value = """
@@ -144,17 +152,18 @@ public class MeetingController {
                                       "created_at": "2024-06-10T13:30:00Z"
                                     }
                                     """))),
-            @ApiResponse(responseCode = "404", description = "Reunião, seller ou cliente não encontrado", content = @Content)
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Reunião, seller ou cliente não encontrado", content = @Content)
     })
     @GetMapping("/{id}")
-    public ResponseEntity<MeetingContextMetadataResponseDTO> getMeetingContextAndMetadata(
+    public ResponseEntity<ApiResponse<MeetingContextMetadataResponseDTO>> getMeetingContextAndMetadata(
             @Parameter(description = "UUID da reunião") @PathVariable UUID id) {
-        return ResponseEntity.ok(getMeetingContextAndMetadataUseCase.execute(id));
+        MeetingContextMetadataResponseDTO meeting = getMeetingContextAndMetadataUseCase.execute(id);
+        return ResponseEntity.ok(ApiResponse.success(meeting, "Reunião encontrada"));
     }
 
     @Operation(summary = "Buscar pós-análise da reunião", description = "Retorna o pós-análise de uma reunião com resumo, itens de ação e análise de sentimento.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Pós-análise encontrada",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Pós-análise encontrada",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = MeetingPostAnalysisResponseDTO.class),
                             examples = @ExampleObject(value = """
@@ -179,20 +188,21 @@ public class MeetingController {
                                       "created_at": "2024-06-10T16:00:00Z"
                                     }
                                     """))),
-            @ApiResponse(responseCode = "404", description = "Pós-análise da reunião não encontrada", content = @Content)
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Pós-análise da reunião não encontrada", content = @Content)
     })
 
     @GetMapping("/{id}/post-analysis")
-    public ResponseEntity<MeetingPostAnalysisResponseDTO> getMeetingPostAnalysis(
+    public ResponseEntity<ApiResponse<MeetingPostAnalysisResponseDTO>> getMeetingPostAnalysis(
             @Parameter(description = "UUID da reunião") @PathVariable UUID id) {
-        return ResponseEntity.ok(getMeetingPostAnalysisUseCase.execute(id));
+        MeetingPostAnalysisResponseDTO postAnalysis = getMeetingPostAnalysisUseCase.execute(id);
+        return ResponseEntity.ok(ApiResponse.success(postAnalysis, "Pós-análise da reunião encontrada"));
     }
 
 
 
     @Operation(summary = "Buscar insights da reunião", description = "Retorna os insights gerados automaticamente para uma reunião.")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Insights encontrados",
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Insights encontrados",
             content = @Content(mediaType = "application/json",
                 schema = @Schema(implementation = MeetingRealtimeInsightsResponseDTO.class),
                 examples = @ExampleObject(value = """
@@ -217,11 +227,12 @@ public class MeetingController {
                       }
                     ]
                 """))),
-        @ApiResponse(responseCode = "404", description = "Reunião não encontrada", content = @Content)
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Reunião não encontrada", content = @Content)
     })
     @GetMapping("/{id}/insights")
-    public ResponseEntity<List<MeetingRealtimeInsightsResponseDTO>> getMeetingRealtimeInsights(
+    public ResponseEntity<ApiResponse<List<MeetingRealtimeInsightsResponseDTO>>> getMeetingRealtimeInsights(
             @Parameter(description = "UUID da reunião") @PathVariable UUID id){
-        return ResponseEntity.ok(getMeetingInsightUseCase.execute(id));
+        List<MeetingRealtimeInsightsResponseDTO> insights = getMeetingInsightUseCase.execute(id);
+        return ResponseEntity.ok(ApiResponse.success(insights, "Insights da reunião encontrados"));
     }
 }

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/MeetingController.java
@@ -87,20 +87,13 @@ public class MeetingController {
                                     """)))
     })
     @GetMapping
-    public ResponseEntity<MeetingPageResponseDTO> getAllMeetings(
+    public ResponseEntity<ApiResponse<MeetingPageResponseDTO>> getAllMeetings(
             @Parameter(description = "Filtrar por título (parcial)") @RequestParam(required = false) String title,
             @Parameter(description = "Filtrar por empresa do cliente (parcial)") @RequestParam(required = false) String clientCompanyName,
             @Parameter(description = "Filtrar por ID do vendedor") @RequestParam(required = false) UUID collaboratorId,
             Pageable pageable) {
         MeetingPageResponseDTO meetings = getAllMeetingsUseCase.execute(title, clientCompanyName, collaboratorId, PageableUtils.normalize(pageable));
-        MeetingPageResponseDTO meetingsWithMessage = new MeetingPageResponseDTO(
-                meetings.content(),
-                meetings.totalElements(),
-                meetings.totalPages(),
-                meetings.summary(),
-                "Reuniões listadas com sucesso"
-        );
-        return ResponseEntity.ok(meetingsWithMessage);
+        return ResponseEntity.ok(ApiResponse.success(meetings, "Reuniões listadas com sucesso"));
     }
 
     @Operation(summary = "Buscar reunião por ID", description = "Retorna os dados completos de contexto e metadados de uma reunião.")

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/SystemStatusController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/SystemStatusController.java
@@ -1,12 +1,12 @@
 package com.salespilot.api.presentation.controller;
 
+import com.salespilot.api.application.dto.ApiResponse;
 import com.salespilot.api.application.dto.SystemStatusResponseDTO;
 import com.salespilot.api.application.usecase.GetSystemStatusUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,18 +25,15 @@ public class SystemStatusController {
     }
 
     @Operation(summary = "Health check", description = "Retorna o status atual da API e o horário da verificação.")
-    @ApiResponse(responseCode = "200", description = "API operacional",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = SystemStatusResponseDTO.class),
-                    examples = @ExampleObject(value = """
-                            {
-                              "current_status": "UP",
-                              "checked_at": "2024-04-15T20:00:00"
-                            }
-                            """)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "API operacional", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SystemStatusResponseDTO.class), examples = @ExampleObject(value = """
+            {
+              "current_status": "UP",
+              "checked_at": "2024-04-15T20:00:00"
+            }
+            """)))
     @GetMapping("/ping")
-    public ResponseEntity<SystemStatusResponseDTO> ping() {
-        return ResponseEntity.ok(getSystemStatusUseCase.execute());
+    public ResponseEntity<ApiResponse<SystemStatusResponseDTO>> ping() {
+        SystemStatusResponseDTO status = getSystemStatusUseCase.execute();
+        return ResponseEntity.ok(ApiResponse.success(status, "API operacional"));
     }
 }

--- a/presentation/src/main/java/com/salespilot/api/presentation/handler/GlobalExceptionHandler.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.salespilot.api.presentation.handler;
 
+import com.salespilot.api.application.dto.ApiResponse;
 import com.salespilot.api.application.exception.ClientNotFoundException;
 import com.salespilot.api.application.exception.CollaboratorAlreadyExistsException;
 import com.salespilot.api.application.exception.CollaboratorNotFoundException;
@@ -18,42 +19,50 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(TaxIdAlreadyExists.class)
-    public ResponseEntity<Void> handleTaxIdAlreadyExists() {
-        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    public ResponseEntity<ApiResponse<Void>> handleTaxIdAlreadyExists() {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.message("CNPJ já cadastrado"));
     }
 
     @ExceptionHandler(CollaboratorAlreadyExistsException.class)
-    public ResponseEntity<Void> handleCollaboratorAlreadyExistsException() {
-        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    public ResponseEntity<ApiResponse<Void>> handleCollaboratorAlreadyExistsException() {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.message("Colaborador já existe nesta empresa com este e-mail"));
     }
 
     @ExceptionHandler(CompanyNotFoundException.class)
-    public ResponseEntity<Void> handleCompanyNotFoundException() {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    public ResponseEntity<ApiResponse<Void>> handleCompanyNotFoundException() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.message("Empresa não encontrada"));
     }
 
     @ExceptionHandler(CollaboratorNotFoundException.class)
-    public ResponseEntity<Void> handleCollaboratorNotFoundException() {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    public ResponseEntity<ApiResponse<Void>> handleCollaboratorNotFoundException() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.message("Colaborador não encontrado"));
     }
 
     @ExceptionHandler(ClientNotFoundException.class)
-    public ResponseEntity<Void> handleClientNotFoundException() {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    public ResponseEntity<ApiResponse<Void>> handleClientNotFoundException() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.message("Cliente não encontrado"));
     }
 
     @ExceptionHandler(MeetingNotFoundException.class)
-    public ResponseEntity<Void> handleMeetingNotFoundException() {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    public ResponseEntity<ApiResponse<Void>> handleMeetingNotFoundException() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.message("Reunião não encontrada"));
     }
 
     @ExceptionHandler(MeetingPostAnalysisNotFoundException.class)
-    public ResponseEntity<Void> handleMeetingPostAnalysisNotFoundException() {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    public ResponseEntity<ApiResponse<Void>> handleMeetingPostAnalysisNotFoundException() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.message("Pós-análise da reunião não encontrada"));
     }
 
     @ExceptionHandler(InvalidCollaboratorRoleException.class)
-    public ResponseEntity<Void> handleInvalidCollaboratorRoleExeption() {
-        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    public ResponseEntity<ApiResponse<Void>> handleInvalidCollaboratorRoleExeption() {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.message("Role inválido para colaborador"));
     }
 }

--- a/presentation/src/main/java/com/salespilot/api/presentation/handler/GlobalExceptionHandler.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/handler/GlobalExceptionHandler.java
@@ -12,8 +12,10 @@ import com.salespilot.api.application.exception.InvalidCollaboratorRoleException
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -64,5 +66,17 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleInvalidCollaboratorRoleExeption() {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(ApiResponse.message("Role inválido para colaborador"));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException() {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(ApiResponse.message("Dados inválidos"));
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHandlerMethodValidationException() {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(ApiResponse.message("Dados inválidos"));
     }
 }


### PR DESCRIPTION
## Issue relacionada

https://github.com/orgs/SalesPilot-AGES/projects/2/views/1?pane=issue&itemId=187791446&issue=SalesPilot-AGES%7CBackend%7C45

## O que foi implementado?

* Criação do dto de ApiResponse para padronização de respostas da API
* Ajuste dos endpoints existentes para retornar mensagem de sucesso
* Ajuste do handler de exception para retornar mensagem de erro

## Por que essa mudança é necessária?

Para que o front possa renderizar mensagens amigáveis de sucesso/erro ao usuario em toasts de acordo com o resultado da ação dele na api

## Como testar?

Rodar e chamar um endpoint, deve retornar {content: <o que vinha antes>, message: string}

## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças