### PR TITLE
fix: discord notify shell injection

### DIFF
--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -39,8 +39,8 @@ jobs:
 
             BODY="$PR_BODY"
             if [ -z "$BODY" ]; then BODY="Sem descrição."; fi
-            TRUNCATED_BODY=$(echo "$BODY" | cut -c1-1000)
-            if [ $(echo "$BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
+            TRUNCATED_BODY="${BODY:0:1000}"
+            [ "${#BODY}" -gt 1000 ] && TRUNCATED_BODY="${TRUNCATED_BODY}..."
 
             THREAD_NAME="PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
             THREAD_NAME=$(echo "$THREAD_NAME" | cut -c1-100)
@@ -113,8 +113,8 @@ jobs:
               EMBED_TITLE=$(echo "$EMBED_TITLE" | cut -c1-256)
 
               if [ -z "$REVIEW_BODY" ]; then REVIEW_BODY="Sem comentário."; fi
-              TRUNCATED_BODY=$(echo "$REVIEW_BODY" | cut -c1-1000)
-              if [ $(echo "$REVIEW_BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
+              TRUNCATED_BODY="${REVIEW_BODY:0:1000}"
+              [ "${#REVIEW_BODY}" -gt 1000 ] && TRUNCATED_BODY="${TRUNCATED_BODY}..."
 
               PAYLOAD=$(jq -n \
                 --arg title "$EMBED_TITLE" \
@@ -141,8 +141,8 @@ jobs:
               EMBED_TITLE="Comentário: PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
               EMBED_TITLE=$(echo "$EMBED_TITLE" | cut -c1-256)
 
-              TRUNCATED_BODY=$(echo "$COMMENT_BODY" | cut -c1-1000)
-              if [ $(echo "$COMMENT_BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
+              TRUNCATED_BODY="${COMMENT_BODY:0:1000}"
+              [ "${#COMMENT_BODY}" -gt 1000 ] && TRUNCATED_BODY="${TRUNCATED_BODY}..."
 
               PAYLOAD=$(jq -n \
                 --arg title "$EMBED_TITLE" \

--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -25,6 +25,9 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           EVENT="${{ github.event_name }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
@@ -34,7 +37,7 @@ jobs:
             ASSIGNEES=$(echo '${{ toJson(github.event.pull_request.assignees) }}' | jq -r '[.[].login] | if length == 0 then "Nenhum" else join(", ") end')
             REVIEWERS=$(echo '${{ toJson(github.event.pull_request.requested_reviewers) }}' | jq -r '[.[].login] | if length == 0 then "Nenhum" else join(", ") end')
 
-            BODY="${{ github.event.pull_request.body }}"
+            BODY="$PR_BODY"
             if [ -z "$BODY" ]; then BODY="Sem descrição."; fi
             TRUNCATED_BODY=$(echo "$BODY" | cut -c1-1000)
             if [ $(echo "$BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
@@ -109,7 +112,6 @@ jobs:
               EMBED_TITLE="Review: PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
               EMBED_TITLE=$(echo "$EMBED_TITLE" | cut -c1-256)
 
-              REVIEW_BODY="${{ github.event.review.body }}"
               if [ -z "$REVIEW_BODY" ]; then REVIEW_BODY="Sem comentário."; fi
               TRUNCATED_BODY=$(echo "$REVIEW_BODY" | cut -c1-1000)
               if [ $(echo "$REVIEW_BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
@@ -139,7 +141,6 @@ jobs:
               EMBED_TITLE="Comentário: PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
               EMBED_TITLE=$(echo "$EMBED_TITLE" | cut -c1-256)
 
-              COMMENT_BODY="${{ github.event.comment.body }}"
               TRUNCATED_BODY=$(echo "$COMMENT_BODY" | cut -c1-1000)
               if [ $(echo "$COMMENT_BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
 


### PR DESCRIPTION
 ## Issue relacionada
                  
  Sem issue — correção de bug identificado nos logs do workflow.

  ## O que foi implementado?

  Corrigido um erro de **shell injection** no workflow `discord-pr-notify.yml` que causava falha com `exit code 127` ao
  abrir PRs cujo corpo continha aspas duplas (ex.: tags HTML como `<img alt="..." src="..." />`).

  ## Por que essa mudança é necessária?

  O campo `${{ github.event.pull_request.body }}` era interpolado diretamente no script shell, dentro de uma atribuição com
   aspas duplas (`BODY="..."`). Quando o corpo do PR continha aspas duplas — o que acontece com qualquer imagem anexada
  pelo GitHub — o shell quebrava a string e interpretava as palavras seguintes como comandos, resultando em erros como:

  /runner/work/_temp/....sh: line 49: de: command not found
  Error: Process completed with exit code 127.

  O mesmo problema existia para o corpo do review (`github.event.review.body`) e de comentários
  (`github.event.comment.body`).

  ## Como foi corrigido?

  Os três campos de texto livre foram movidos para variáveis de ambiente no bloco `env:` do step:

  ```yaml
  PR_BODY: ${{ github.event.pull_request.body }}
  REVIEW_BODY: ${{ github.event.review.body }}
  COMMENT_BODY: ${{ github.event.comment.body }}

  O GitHub Actions serializa os valores de env vars de forma segura, sem renderizá-los como parte do script. O shell então
  os lê via $PR_BODY, $REVIEW_BODY e $COMMENT_BODY, sem risco de quebra por caracteres especiais.

  Checklist

  - O código foi revisado pelo próprio autor antes de abrir o MR
  - A implementação não quebra funcionalidades existentes
  - Não há novos testes necessários (correção de configuração de CI)