### PR TITLE
sonar-fix: add the private construtor to DashboardPeriodUtils

### DIFF
--- a/application/src/main/java/com/salespilot/api/application/utils/DashboardPeriodUtils.java
+++ b/application/src/main/java/com/salespilot/api/application/utils/DashboardPeriodUtils.java
@@ -8,7 +8,6 @@ import java.time.temporal.ChronoUnit;
 import com.salespilot.api.application.exception.InvalidPeriodException;
 
 public class DashboardPeriodUtils {
-    
     private DashboardPeriodUtils() {}
 
     public static LocalDateTime[] dashboardPeriodUtilsToCardMetrics(String period, LocalDate startDate, LocalDate endDate) {

--- a/application/src/main/java/com/salespilot/api/application/utils/DashboardPeriodUtils.java
+++ b/application/src/main/java/com/salespilot/api/application/utils/DashboardPeriodUtils.java
@@ -8,6 +8,9 @@ import java.time.temporal.ChronoUnit;
 import com.salespilot.api.application.exception.InvalidPeriodException;
 
 public class DashboardPeriodUtils {
+    
+    private DashboardPeriodUtils() {}
+
     public static LocalDateTime[] dashboardPeriodUtilsToCardMetrics(String period, LocalDate startDate, LocalDate endDate) {
         LocalDateTime previousEnd;
         LocalDateTime previousStart;


### PR DESCRIPTION
## Issue relacionada

https://github.com/SalesPilot-AGES/Backend/issues/24

## O que foi implementado?

Foi adicionado um construtor privado na classe de DashboardPeriodUtils

## Por que essa mudança é necessária?

Como a classe de DashboardPeriodUtils contém apenas métodos static, seria desnecessário que alguém instancie um novo DashboardPeriodUtils. Para evitar isso é adicionado um construtor privado na classe.

## Como testar?

Tente dar um new DashboardPeriodUtils() fora da classe e veja que não funciona 

## Checklist

- [ X ] O código foi revisado pelo próprio autor antes de abrir o MR
- [ X ] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças