### PR TITLE
sonar-fix: changing chain of if/else with a switch expression in MeetingRepositoryImpl

### DIFF
--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRepositoryImpl.java
@@ -95,15 +95,20 @@ public class MeetingRepositoryImpl implements MeetingRepository{
 
         LocalDate month;
 
-        if (rawMonth instanceof Timestamp timestamp) {
-            month = timestamp.toLocalDateTime().toLocalDate();
-        } else if (rawMonth instanceof LocalDateTime localDateTime) {
-            month = localDateTime.toLocalDate();
-        } else if (rawMonth instanceof LocalDate localDate) {
-            month = localDate;
-        } else {
-            throw new IllegalStateException("Tipo inesperado para month: " + rawMonth.getClass());
+        switch (rawMonth) {
+            case Timestamp timestamp: 
+                month = timestamp.toLocalDateTime().toLocalDate();
+                break;
+            case LocalDateTime localDateTime:
+                month = localDateTime.toLocalDate();
+                break;
+            case LocalDate localDate:
+                month = localDate;
+                break;
+            default:
+                throw new IllegalStateException("Tipo inesperado para month: " + rawMonth.getClass());
         }
+        
         Long total = ((Number) item[1]).longValue();
         String monthLabel = month.getMonth().getDisplayName(TextStyle.SHORT, Locale.of("pt", "BR")).replace(".", "");
 

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingRepositoryImpl.java
@@ -106,7 +106,7 @@ public class MeetingRepositoryImpl implements MeetingRepository{
                 month = localDate;
                 break;
             default:
-                throw new IllegalStateException("Tipo inesperado para month: " + rawMonth.getClass());
+                throw new IllegalStateException("Unexpected type for the month: " + rawMonth.getClass());
         }
         
         Long total = ((Number) item[1]).longValue();


### PR DESCRIPTION
## Issue relacionada

https://github.com/SalesPilot-AGES/Backend/issues/24

## O que foi implementado?

Troca de uma corrente if e else seguidos no método de mapear para mês e total por um switch case

## Por que essa mudança é necessária?

Para deixar o código mais limpo e melhorar performance

## Como testar?

Fazer um teste com as requisições da task agrupar reuniões por mês e ver se funciona

## Checklist

- [ X ] O código foi revisado pelo próprio autor antes de abrir o MR
- [ X ] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças