### PR TITLE
refactor: make CORS allowed origins configurable via environment

### DIFF
--- a/bootstrap/src/main/resources/application.properties
+++ b/bootstrap/src/main/resources/application.properties
@@ -33,6 +33,9 @@ spring.flyway.baseline-on-migrate=${FLYWAY_BASELINE_ON_MIGRATE}
 spring.flyway.baseline-version=1
 spring.flyway.baseline-description=baseline_existing_schema
 
+# Security / CORS
+app.security.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:5174}
+
 # Security / JWT
 app.security.jwt.secret=${JWT_SECRET}
 app.security.jwt.issuer=${JWT_ISSUER}

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/SecurityConfig.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.salespilot.api.infrastructure.config;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -18,6 +19,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableMethodSecurity
 @Configuration
 public class SecurityConfig {
+
+    @Value("${app.security.cors.allowed-origins}")
+    private List<String> allowedOrigins;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -44,7 +48,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:5174"));
+        config.setAllowedOrigins(allowedOrigins);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);


### PR DESCRIPTION
## What

Move as origens permitidas do CORS de hardcoded no `SecurityConfig` pra propriedade `app.security.cors.allowed-origins`, configurável via env var `CORS_ALLOWED_ORIGINS` (lista separada por vírgula). Default mantém o comportamento atual: `http://localhost:5173,http://localhost:5174`.

## Why

Hoje qualquer mudança de origem (domínio próprio, novo ambiente) exige rebuild da imagem. Com env var, é só ajustar o `.env` do servidor e reiniciar o container.

Nota: em produção o CORS nem é exercitado depois do proxy nginx no Frontend (SalesPilot-AGES/Frontend#74) — requisições same-origin não passam por preflight. O default de localhost segue atendendo o fluxo de dev local (vite). Nenhuma config nova é necessária no servidor.

## How to review

- `SecurityConfig`: `@Value` injetando a lista no lugar do `List.of(...)` hardcoded
- `application.properties`: nova propriedade com default
- Compilação validada localmente

## Checklist

- [x] Self-review performed
- [ ] Tests cover the changes
- [x] No breaking changes (or explained above)