### PR TITLE
refactor: add stats to company class and necessary endpoints

### DIFF
--- a/application/src/main/java/com/salespilot/api/application/dto/CompanyResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/CompanyResponseDTO.java
@@ -1,9 +1,9 @@
 package com.salespilot.api.application.dto;
 
+import com.salespilot.api.domain.entity.Company;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
-
-import com.salespilot.api.domain.entity.Company;
 
 public record CompanyResponseDTO(
         UUID id,
@@ -14,7 +14,10 @@ public record CompanyResponseDTO(
         boolean active,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        String plan
+        String plan,
+        Long totalMeetings,
+        Long totalCollaborators,
+        Long totalManagers
 ) {
     public static CompanyResponseDTO from(Company company) {
         return new CompanyResponseDTO(
@@ -26,7 +29,10 @@ public record CompanyResponseDTO(
                 company.isActive(),
                 company.getCreatedAt(),
                 company.getUpdatedAt(),
-                company.getPlan()
+                company.getPlan(),
+                company.getTotalMeetings(),
+                company.getTotalCollaborators(),
+                company.getTotalManagers()
         );
     }
 }

--- a/domain/src/main/java/com/salespilot/api/domain/entity/Company.java
+++ b/domain/src/main/java/com/salespilot/api/domain/entity/Company.java
@@ -1,14 +1,16 @@
 package com.salespilot.api.domain.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.With;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 @Getter
 @AllArgsConstructor
+@With
 public class Company {
     private UUID id;
     private String name;
@@ -20,4 +22,7 @@ public class Company {
     private LocalDateTime updatedAt;
     private String plan;
     private List<Collaborator> collaborators;
+    private Long totalMeetings;
+    private Long totalCollaborators;
+    private Long totalManagers;
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/mapper/CompanyMapper.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/mapper/CompanyMapper.java
@@ -9,12 +9,10 @@ import java.util.List;
 
 @Component
 public class CompanyMapper {
+    private static final Long DEFAULT_UNSPECIFIED_LONG = 0L;
+
     public Company toDomain(CompanyEntity entity) {
-        String plan = entity.getSubscriptions().stream()
-                .filter(CompanySubscriptions::isActive)
-                .findFirst()
-                .map(it -> it.getSubscriptionPlans().getName())
-                .orElse(null);
+        String plan = resolvePlan(entity);
 
         return new Company(
                 entity.getId(),
@@ -26,7 +24,18 @@ public class CompanyMapper {
                 entity.getCreatedAt(),
                 entity.getUpdatedAt(),
                 plan,
-                List.of()
+                List.of(),
+                DEFAULT_UNSPECIFIED_LONG,
+                DEFAULT_UNSPECIFIED_LONG,
+                DEFAULT_UNSPECIFIED_LONG
         );
+    }
+
+    public String resolvePlan(CompanyEntity entity) {
+        return entity.getSubscriptions().stream()
+                .filter(CompanySubscriptions::isActive)
+                .findFirst()
+                .map(it -> it.getSubscriptionPlans().getName())
+                .orElse(null);
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyJpaRepository.java
@@ -1,19 +1,18 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
+import com.salespilot.api.infrastructure.persistence.jpa.entity.CompanyEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 
-import com.salespilot.api.infrastructure.persistence.jpa.entity.CompanyEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 
 public interface CompanyJpaRepository extends JpaRepository<CompanyEntity, UUID>, JpaSpecificationExecutor<CompanyEntity>  {
@@ -40,11 +39,25 @@ public interface CompanyJpaRepository extends JpaRepository<CompanyEntity, UUID>
     """, nativeQuery = true)
     List<Object[]> getTopFiveCompaniesByMeetingTotal(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
-    
+
     @Query("""
         SELECT c.active, COUNT(c)
         FROM CompanyEntity c
         GROUP BY c.active
     """)
     List<Object[]> countCompaniesGroupedByStatus();
+
+    @Query(value = """
+        SELECT 
+            c.id AS company_id,
+            COUNT(DISTINCT col.id) AS total_collaborators,
+            COUNT(DISTINCT CASE WHEN col.role = 'MANAGER' THEN col.id END) AS total_managers,
+            COUNT(DISTINCT m.id) AS total_meetings
+        FROM companies c
+        LEFT JOIN collaborators col ON col.company_id = c.id
+        LEFT JOIN meetings m ON m.collaborator_id = col.id
+        WHERE c.id IN :ids
+        GROUP BY c.id
+    """, nativeQuery = true)
+    List<Object[]> getStatsByCompanyIds(@Param("ids") List<UUID> ids);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
@@ -1,16 +1,5 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.salespilot.api.domain.entity.Company;
 import com.salespilot.api.domain.model.CompanyStatusCount;
 import com.salespilot.api.domain.repository.CompanyRepository;
@@ -21,6 +10,18 @@ import com.salespilot.api.infrastructure.persistence.jpa.entity.SubscriptionPlan
 import com.salespilot.api.infrastructure.persistence.jpa.mapper.CompanyMapper;
 import com.salespilot.api.infrastructure.persistence.jpa.specification.CompanySpecification;
 import com.salespilot.api.model.CompanyNameAndTotalMeetings;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Repository
 public class CompanyRepositoryImpl implements CompanyRepository {
@@ -51,13 +52,39 @@ public class CompanyRepositoryImpl implements CompanyRepository {
                 .and(CompanySpecification.planEquals(plan))
                 .and(CompanySpecification.isActiveEquals(active));
 
-        return companyJpaRepository.findAll(spec, pageable).map(mapper::toDomain);
+        Page<CompanyEntity> page = companyJpaRepository.findAll(spec, pageable);
+
+        List<UUID> ids = page.getContent().stream().map(CompanyEntity::getId).toList();
+
+        Map<UUID, Object[]> statsMap = fetchStatsMap(ids);
+        return page.map(entity -> enrichWithStats(entity, statsMap));
     }
 
     @Transactional(readOnly = true)
     @Override
     public Optional<Company> getCompanyById(UUID id) {
-        return companyJpaRepository.findById(id).map(mapper::toDomain);
+        return companyJpaRepository.findById(id).map(entity -> {
+            Map<UUID, Object[]> statsMap = fetchStatsMap(List.of(id));
+            return enrichWithStats(entity, statsMap);
+        });
+    }
+
+    private Company enrichWithStats(CompanyEntity entity, Map<UUID, Object[]> statsMap) {
+        Object[] stats = statsMap.get(entity.getId());
+        long totalMeetings = stats != null ? ((Number) stats[3]).longValue() : 0L;
+        long totalCollaborators = stats != null ? ((Number) stats[1]).longValue() : 0L;
+        long totalManagers = stats != null ? ((Number) stats[2]).longValue() : 0L;
+
+        return mapper.toDomain(entity)
+                .withTotalMeetings(totalMeetings)
+                .withTotalCollaborators(totalCollaborators)
+                .withTotalManagers(totalManagers);
+    }
+
+    private Map<UUID, Object[]> fetchStatsMap(List<UUID> ids) {
+        return companyJpaRepository.getStatsByCompanyIds(ids)
+                .stream()
+                .collect(Collectors.toMap(row -> UUID.fromString(row[0].toString()), row -> row));
     }
 
     @Transactional
@@ -73,7 +100,9 @@ public class CompanyRepositoryImpl implements CompanyRepository {
                         companyStatusHistoryJpaRepository.save(new CompanyStatusHistoryEntity(entity, active));
                     }
                     updateSubscription(entity, plan);
-                    return mapper.toDomain(entity);
+
+                    Map<UUID, Object[]> statsMap = fetchStatsMap(List.of(id));
+                    return enrichWithStats(entity, statsMap);
                 });
     }
 

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/CompanyController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/CompanyController.java
@@ -42,7 +42,7 @@ public class CompanyController {
 
     private final PostCompanyUseCase postCompanyUseCase;
     private final GetCompanyByIdUseCase getCompanyByIdUseCase;
-    private final GetAllCompaniesUseCase getCompanyUseCase;
+    private final GetAllCompaniesUseCase getAllCompaniesUseCase;
     private final UpdateCompanyUseCase updateCompanyUseCase;
 
     private static final int MAX_PAGE_SIZE = 100;
@@ -61,11 +61,11 @@ public class CompanyController {
 
     public CompanyController(PostCompanyUseCase postCompanyUseCase,
                              GetCompanyByIdUseCase getCompanyByIdUseCase,
-                             GetAllCompaniesUseCase getCompanyUseCase,
+                             GetAllCompaniesUseCase getAllCompaniesUseCase,
                              UpdateCompanyUseCase updateCompanyUseCase) {
         this.postCompanyUseCase = postCompanyUseCase;
         this.getCompanyByIdUseCase = getCompanyByIdUseCase;
-        this.getCompanyUseCase = getCompanyUseCase;
+        this.getAllCompaniesUseCase = getAllCompaniesUseCase;
         this.updateCompanyUseCase = updateCompanyUseCase;
     }
 
@@ -175,7 +175,7 @@ public class CompanyController {
             @Parameter(description = "Filtro por status de ativação") @RequestParam(required = false) Boolean active,
             Pageable pageable) {
         Pageable safePageable = normalizePageable(pageable);
-        Page<CompanyResponseDTO> companies = getCompanyUseCase.execute(name, taxId, plan, active, safePageable);
+        Page<CompanyResponseDTO> companies = getAllCompaniesUseCase.execute(name, taxId, plan, active, safePageable);
         return ResponseEntity.ok(ApiResponse.success(PaginatedResponse.from(companies), "Empresas listadas com sucesso"));
     }
 


### PR DESCRIPTION
## Issue relacionada

https://github.com/SalesPilot-AGES/Backend/issues/74

## O que foi implementado?

Foram adicionados os parâmetros de totalMeetings, totalCollaborators e totalManagers (dados de cards no front) ao CompanyResposeDTO já existente e à classe domain Company, adaptando o código que estava lá.

## Por que essa mudança é necessária?

O frontend necessita mostrar esses dados nos stat cards e facilita se forem passados no mesmo objeto da empresa.

## Como testar?

acessar com GET os endpoints /api/companies e /api/companies/{id}
também foi implementado no endpoint PUT /api/companies/{id}, porém não sei se é necessário.

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças