### PR TITLE
fix(application): corrige testCompile de GetCollaboratorByIdUseCaseTest

### DIFF
--- a/application/src/test/java/com/salespilot/api/application/usecase/GetCollaboratorByIdUseCaseTest.java
+++ b/application/src/test/java/com/salespilot/api/application/usecase/GetCollaboratorByIdUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.salespilot.api.application.usecase;
 
 import com.salespilot.api.application.assembler.CollaboratorAssembler;
+import com.salespilot.api.application.dto.AuthUserDTO;
 import com.salespilot.api.application.dto.CollaboratorResponseDTO;
 import com.salespilot.api.application.exception.CollaboratorNotFoundException;
 import com.salespilot.api.application.exception.CompanyNotFoundException;
@@ -44,6 +45,7 @@ class GetCollaboratorByIdUseCaseTest {
     private final UUID collaboratorId = UUID.randomUUID();
     private final LocalDateTime now = LocalDateTime.now();
     private final CollaboratorPreferences preferences = new CollaboratorPreferences("light", "gpt-4o");
+    private final AuthUserDTO authUser = new AuthUserDTO(CollaboratorRole.SYSTEM_ADMIN, UUID.randomUUID(), companyId);
 
     private Collaborator buildCollaborator() {
         return new Collaborator(collaboratorId, companyId, "João", "joao@acme.com", "+55 11 99999-0000", CollaboratorRole.MANAGER, true, preferences, now, now);
@@ -62,7 +64,7 @@ class GetCollaboratorByIdUseCaseTest {
         when(collaboratorQueryService.getOrThrowById(collaboratorId)).thenReturn(buildCollaborator());
         when(companyQueryService.getOrThrowById(companyId)).thenReturn(buildCompany());
 
-        CollaboratorResponseDTO result = useCase.execute(collaboratorId);
+        CollaboratorResponseDTO result = useCase.execute(collaboratorId, authUser);
 
         assertEquals(collaboratorId, result.id());
         assertEquals(companyId, result.companyId());
@@ -76,7 +78,7 @@ class GetCollaboratorByIdUseCaseTest {
     void shouldThrowWhenCollaboratorNotFound() {
         when(collaboratorQueryService.getOrThrowById(collaboratorId)).thenThrow(new CollaboratorNotFoundException(collaboratorId));
 
-        assertThrows(CollaboratorNotFoundException.class, () -> useCase.execute(collaboratorId));
+        assertThrows(CollaboratorNotFoundException.class, () -> useCase.execute(collaboratorId, authUser));
 
         verifyNoInteractions(companyQueryService);
     }
@@ -86,7 +88,7 @@ class GetCollaboratorByIdUseCaseTest {
         when(collaboratorQueryService.getOrThrowById(collaboratorId))
                 .thenReturn(buildCollaboratorWithRole(CollaboratorRole.SELLER));
 
-        assertThrows(InvalidCollaboratorRoleException.class, () -> useCase.execute(collaboratorId));
+        assertThrows(InvalidCollaboratorRoleException.class, () -> useCase.execute(collaboratorId, authUser));
 
         verifyNoInteractions(companyQueryService);
     }
@@ -96,6 +98,6 @@ class GetCollaboratorByIdUseCaseTest {
         when(collaboratorQueryService.getOrThrowById(collaboratorId)).thenReturn(buildCollaborator());
         when(companyQueryService.getOrThrowById(companyId)).thenThrow(new CompanyNotFoundException(companyId));
 
-        assertThrows(CompanyNotFoundException.class, () -> useCase.execute(collaboratorId));
+        assertThrows(CompanyNotFoundException.class, () -> useCase.execute(collaboratorId, authUser));
     }
 }


### PR DESCRIPTION
## Issue relacionada

<!-- Link da issue no GitHub. -->

## O que foi implementado?

Atualização do teste `GetCollaboratorByIdUseCaseTest` para a nova assinatura de `GetCollaboratorByIdUseCase.execute(UUID, AuthUserDTO)`:

- Adicionado import e campo `AuthUserDTO authUser` (perfil `SYSTEM_ADMIN`, que libera o acesso em `CollaboratorAccessUtils.grantSelfOrAdminAccess`).
- As 4 chamadas a `useCase.execute(collaboratorId)` passaram a incluir o `authUser`.

## Por que essa mudança é necessária?

O método `execute` passou a exigir `(UUID, AuthUserDTO)` após a inclusão do controle de acesso, mas o teste continuava chamando apenas com `UUID`. Isso quebrava o `testCompile` no step de build do Docker da action (`./mvnw clean package -DskipTests` **compila** os testes — `-DskipTests` só pula a execução, não a compilação), fazendo o job `docker-build-push` falhar.

## Como testar?

```bash
export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
./mvnw -pl application -am test -Dtest=GetCollaboratorByIdUseCaseTest -Dsurefire.failIfNoSpecifiedTests=false
```

Resultado local: `Tests run: 4, Failures: 0, Errors: 0` — BUILD SUCCESS.

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [x] Testes foram adicionados ou atualizados para cobrir as mudanças
