### PR TITLE
fix(presentation): corrige testCompile de CollaboratorControllerTest

### DIFF
--- a/presentation/src/test/java/com/salespilot/api/presentation/controller/CollaboratorControllerTest.java
+++ b/presentation/src/test/java/com/salespilot/api/presentation/controller/CollaboratorControllerTest.java
@@ -177,7 +177,8 @@ class CollaboratorControllerTest {
 
     @Test
     void shouldGetManagerByIdAndReturn200() throws Exception {
-        when(getCollaboratorByIdUseCase.execute(id)).thenReturn(buildCollaboratorResponse(CollaboratorRole.MANAGER));
+        setAdminAuth();
+        when(getCollaboratorByIdUseCase.execute(any(), any())).thenReturn(buildCollaboratorResponse(CollaboratorRole.MANAGER));
 
         mockMvc.perform(get("/api/collaborators/managers/{id}", id))
                 .andExpect(status().isOk())
@@ -186,7 +187,8 @@ class CollaboratorControllerTest {
 
     @Test
     void shouldReturn404WhenManagerNotFound() throws Exception {
-        when(getCollaboratorByIdUseCase.execute(id)).thenThrow(new CollaboratorNotFoundException(id));
+        setAdminAuth();
+        when(getCollaboratorByIdUseCase.execute(any(), any())).thenThrow(new CollaboratorNotFoundException(id));
 
         mockMvc.perform(get("/api/collaborators/managers/{id}", id))
                 .andExpect(status().isNotFound());


### PR DESCRIPTION
## Issue relacionada

<!-- Link da issue no GitHub. -->

## O que foi implementado?

Correção do `CollaboratorControllerTest` (módulo `presentation`) para a nova assinatura de `GetCollaboratorByIdUseCase.execute(UUID, AuthUserDTO)`:

- `shouldGetManagerByIdAndReturn200` e `shouldReturn404WhenManagerNotFound`: as chamadas a `getCollaboratorByIdUseCase.execute(id)` passaram para `execute(any(), any())`, seguindo o padrão já usado no teste análogo de seller.
- Adicionado `setAdminAuth()` no início dos dois testes — o endpoint passou a resolver o `AuthUserDTO` a partir do JWT, então sem o `setAdminAuth()` (que injeta o JWT no `SecurityContext`) os testes davam `NullPointerException`.

## Por que essa mudança é necessária?

Este é o **segundo** arquivo de teste quebrado pela mudança de assinatura de `execute` (o primeiro, no módulo `application`, foi corrigido no PR #83). O `testCompile` do módulo `presentation` falhava no step de build do Docker (`./mvnw clean package -DskipTests` compila os testes), derrubando o job `docker-build-push` nas branches `development` e `main`.

## Como testar?

```bash
export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
./mvnw -pl presentation -am test -Dtest=CollaboratorControllerTest -Dsurefire.failIfNoSpecifiedTests=false
```

Resultado local: `Tests run: 12, Failures: 0, Errors: 0` — BUILD SUCCESS. Também validado `./mvnw test-compile` em todos os módulos (exit 0).

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [x] Testes foram adicionados ou atualizados para cobrir as mudanças
