### PR TITLE
feat: add sellers status count to dashboard

### DIFF
--- a/application/src/main/java/com/salespilot/api/application/dto/DashboardStatusCountDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/DashboardStatusCountDTO.java
@@ -1,6 +1,6 @@
 package com.salespilot.api.application.dto;
 
-public record CompanyStatusCountDTO(
+public record DashboardStatusCountDTO(
     String label,
     Long value
 ) {

--- a/application/src/main/java/com/salespilot/api/application/dto/GroupStatusCountResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/GroupStatusCountResponseDTO.java
@@ -2,8 +2,8 @@ package com.salespilot.api.application.dto;
 
 import java.util.List;
 
-public record GroupCompanyCountResponseDTO(
-    List<CompanyStatusCountDTO> data,
+public record GroupStatusCountResponseDTO(
+    List<DashboardStatusCountDTO> data,
     Long total
 ) {
 }

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetGroupedCompaniesCountUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetGroupedCompaniesCountUseCase.java
@@ -1,11 +1,11 @@
 package com.salespilot.api.application.usecase;
 
-import java.util.List;
-
-import com.salespilot.api.application.dto.CompanyStatusCountDTO;
-import com.salespilot.api.application.dto.GroupCompanyCountResponseDTO;
-import com.salespilot.api.domain.model.CompanyStatusCount;
+import com.salespilot.api.application.dto.DashboardStatusCountDTO;
+import com.salespilot.api.application.dto.GroupStatusCountResponseDTO;
+import com.salespilot.api.domain.model.StatusCount;
 import com.salespilot.api.domain.repository.CompanyRepository;
+
+import java.util.List;
 
 public class GetGroupedCompaniesCountUseCase {
     private final CompanyRepository companyRepository;
@@ -14,22 +14,22 @@ public class GetGroupedCompaniesCountUseCase {
         this.companyRepository = companyRepository;
     }
 
-    public GroupCompanyCountResponseDTO execute() {
+    public GroupStatusCountResponseDTO execute() {
 
-        List<CompanyStatusCountDTO> data = companyRepository
+        List<DashboardStatusCountDTO> data = companyRepository
             .countCompaniesGroupedByStatus()
             .stream()
             .map(this::mapToDto)
             .toList();
 
         Long total = data.stream()
-            .mapToLong(CompanyStatusCountDTO::value)
+            .mapToLong(DashboardStatusCountDTO::value)
             .sum();
 
-        return new GroupCompanyCountResponseDTO(data, total);
+        return new GroupStatusCountResponseDTO(data, total);
     }
 
-    private CompanyStatusCountDTO mapToDto(CompanyStatusCount item) {
-        return new CompanyStatusCountDTO(item.active() ? "Ativas" : "Inativas", item.total());
+    private DashboardStatusCountDTO mapToDto(StatusCount item) {
+        return new DashboardStatusCountDTO(item.active() ? "Ativas" : "Inativas", item.total());
     }
 }

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetGroupedSellersCountUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetGroupedSellersCountUseCase.java
@@ -1,0 +1,35 @@
+package com.salespilot.api.application.usecase;
+
+import com.salespilot.api.application.dto.DashboardStatusCountDTO;
+import com.salespilot.api.application.dto.GroupStatusCountResponseDTO;
+import com.salespilot.api.domain.model.StatusCount;
+import com.salespilot.api.domain.repository.CollaboratorRepository;
+
+import java.util.List;
+
+public class GetGroupedSellersCountUseCase {
+    private final CollaboratorRepository collaboratorRepository;
+
+    public GetGroupedSellersCountUseCase(CollaboratorRepository collaboratorRepository) {
+        this.collaboratorRepository = collaboratorRepository;
+    }
+
+    public GroupStatusCountResponseDTO execute() {
+
+        List<DashboardStatusCountDTO> data = collaboratorRepository
+                .countSellersGroupedByStatus()
+                .stream()
+                .map(this::mapToDto)
+                .toList();
+
+        Long total = data.stream()
+                .mapToLong(DashboardStatusCountDTO::value)
+                .sum();
+
+        return new GroupStatusCountResponseDTO(data, total);
+    }
+
+    private DashboardStatusCountDTO mapToDto(StatusCount item) {
+        return new DashboardStatusCountDTO(item.active() ? "Ativos" : "Inativos", item.total());
+    }
+}

--- a/application/src/test/java/com/salespilot/api/application/usecase/GetGroupedCompaniesCountUseCaseTest.java
+++ b/application/src/test/java/com/salespilot/api/application/usecase/GetGroupedCompaniesCountUseCaseTest.java
@@ -1,7 +1,7 @@
 package com.salespilot.api.application.usecase;
 
-import com.salespilot.api.application.dto.GroupCompanyCountResponseDTO;
-import com.salespilot.api.domain.model.CompanyStatusCount;
+import com.salespilot.api.application.dto.GroupStatusCountResponseDTO;
+import com.salespilot.api.domain.model.StatusCount;
 import com.salespilot.api.domain.repository.CompanyRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,8 +11,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class GetGroupedCompaniesCountUseCaseTest {
@@ -26,10 +27,10 @@ class GetGroupedCompaniesCountUseCaseTest {
     @Test
     void shouldReturnActiveAndInactiveLabels() {
         when(companyRepository.countCompaniesGroupedByStatus()).thenReturn(
-                List.of(new CompanyStatusCount(true, 10L), new CompanyStatusCount(false, 3L))
+                List.of(new StatusCount(true, 10L), new StatusCount(false, 3L))
         );
 
-        GroupCompanyCountResponseDTO result = useCase.execute();
+        GroupStatusCountResponseDTO result = useCase.execute();
 
         assertEquals(2, result.data().size());
         assertEquals("Ativas", result.data().get(0).label());
@@ -41,10 +42,10 @@ class GetGroupedCompaniesCountUseCaseTest {
     @Test
     void shouldSumTotalCorrectly() {
         when(companyRepository.countCompaniesGroupedByStatus()).thenReturn(
-                List.of(new CompanyStatusCount(true, 10L), new CompanyStatusCount(false, 3L))
+                List.of(new StatusCount(true, 10L), new StatusCount(false, 3L))
         );
 
-        GroupCompanyCountResponseDTO result = useCase.execute();
+        GroupStatusCountResponseDTO result = useCase.execute();
 
         assertEquals(13L, result.total());
     }
@@ -53,7 +54,7 @@ class GetGroupedCompaniesCountUseCaseTest {
     void shouldReturnZeroTotal_whenRepositoryReturnsEmpty() {
         when(companyRepository.countCompaniesGroupedByStatus()).thenReturn(List.of());
 
-        GroupCompanyCountResponseDTO result = useCase.execute();
+        GroupStatusCountResponseDTO result = useCase.execute();
 
         assertTrue(result.data().isEmpty());
         assertEquals(0L, result.total());
@@ -62,10 +63,10 @@ class GetGroupedCompaniesCountUseCaseTest {
     @Test
     void shouldMapInactiveCompaniesToInativasLabel() {
         when(companyRepository.countCompaniesGroupedByStatus()).thenReturn(
-                List.of(new CompanyStatusCount(false, 7L))
+                List.of(new StatusCount(false, 7L))
         );
 
-        GroupCompanyCountResponseDTO result = useCase.execute();
+        GroupStatusCountResponseDTO result = useCase.execute();
 
         assertEquals("Inativas", result.data().get(0).label());
         assertEquals(7L, result.total());

--- a/domain/src/main/java/com/salespilot/api/domain/model/StatusCount.java
+++ b/domain/src/main/java/com/salespilot/api/domain/model/StatusCount.java
@@ -1,6 +1,6 @@
 package com.salespilot.api.domain.model;
 
-public record CompanyStatusCount(
+public record StatusCount(
     boolean active,
     Long total
 ) {

--- a/domain/src/main/java/com/salespilot/api/domain/repository/CollaboratorRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/CollaboratorRepository.java
@@ -2,11 +2,13 @@ package com.salespilot.api.domain.repository;
 
 import com.salespilot.api.domain.entity.Collaborator;
 import com.salespilot.api.domain.enums.CollaboratorRole;
+import com.salespilot.api.domain.model.StatusCount;
 import com.salespilot.api.domain.valueobject.CollaboratorPreferences;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -23,4 +25,5 @@ public interface CollaboratorRepository {
     Long countSellersByCompanyIdAndActiveValue(UUID companyId, boolean active);
     Long countActiveSellersByCompanyIdAndPeriod(UUID companyId, LocalDateTime period);
     Long countInactiveSellersByCompanyIdAndPeriod(UUID companyId, LocalDateTime period);
+    List<StatusCount> countSellersGroupedByStatus();
 }

--- a/domain/src/main/java/com/salespilot/api/domain/repository/CompanyRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/CompanyRepository.java
@@ -1,11 +1,10 @@
 package com.salespilot.api.domain.repository;
 
+import com.salespilot.api.domain.entity.Company;
+import com.salespilot.api.domain.model.StatusCount;
+import com.salespilot.api.model.CompanyNameAndTotalMeetings;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-
-import com.salespilot.api.domain.entity.Company;
-import com.salespilot.api.domain.model.CompanyStatusCount;
-import com.salespilot.api.model.CompanyNameAndTotalMeetings;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,7 +18,7 @@ public interface CompanyRepository {
     Optional<Company> getCompanyById(UUID id);
     Optional<Company> updateCompany(UUID id, String name, String plan, boolean active);
     List<CompanyNameAndTotalMeetings> getTopFiveCompaniesByMeetingTotal(LocalDateTime start, LocalDateTime end);
-    List<CompanyStatusCount> countCompaniesGroupedByStatus();
+    List<StatusCount> countCompaniesGroupedByStatus();
     Long countCompaniesByActiveValueAndPeriod(boolean active, LocalDateTime period);
     Long countCompaniesByActiveValue(boolean active);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
@@ -15,11 +15,12 @@ import com.salespilot.api.application.usecase.GetAllCompaniesUseCase;
 import com.salespilot.api.application.usecase.GetAllManagersUseCase;
 import com.salespilot.api.application.usecase.GetAllMeetingsUseCase;
 import com.salespilot.api.application.usecase.GetAllSellersUseCase;
-import com.salespilot.api.application.usecase.GetCardMetricsUseCase;
 import com.salespilot.api.application.usecase.GetAverageMeetingDurationPerMonthUseCase;
+import com.salespilot.api.application.usecase.GetCardMetricsUseCase;
 import com.salespilot.api.application.usecase.GetCollaboratorByIdUseCase;
 import com.salespilot.api.application.usecase.GetCompanyByIdUseCase;
 import com.salespilot.api.application.usecase.GetGroupedCompaniesCountUseCase;
+import com.salespilot.api.application.usecase.GetGroupedSellersCountUseCase;
 import com.salespilot.api.application.usecase.GetMeetingContextAndMetadataUseCase;
 import com.salespilot.api.application.usecase.GetMeetingInsightUseCase;
 import com.salespilot.api.application.usecase.GetMeetingPostAnalysisUseCase;
@@ -148,5 +149,10 @@ public class UseCaseConfig {
     @Bean
     public GetAverageMeetingDurationPerMonthUseCase getAverageMeetingDurationPerMonthUseCase(MeetingRepository meetingRepository) {
         return new GetAverageMeetingDurationPerMonthUseCase(meetingRepository);
+    }
+
+    @Bean
+    public GetGroupedSellersCountUseCase getGroupedSellersCountUseCase(CollaboratorRepository collaboratorRepository) {
+        return new GetGroupedSellersCountUseCase(collaboratorRepository);
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CollaboratorJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CollaboratorJpaRepository.java
@@ -1,14 +1,23 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
-import java.util.Optional;
-import java.util.UUID;
-
+import com.salespilot.api.infrastructure.persistence.jpa.entity.CollaboratorEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
-import com.salespilot.api.infrastructure.persistence.jpa.entity.CollaboratorEntity;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface CollaboratorJpaRepository extends JpaRepository<CollaboratorEntity, UUID>, JpaSpecificationExecutor<CollaboratorEntity> {
     boolean existsByCompanyIdAndEmail(UUID companyId, String email);
     Optional<CollaboratorEntity> findByEmail(String email);
+
+    @Query("""
+    SELECT c.active, COUNT(c)
+    FROM CollaboratorEntity c
+    WHERE c.role = com.salespilot.api.domain.enums.CollaboratorRole.SELLER
+    GROUP BY c.active
+""")
+    List<Object[]> countSellersGroupedByStatus();
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CollaboratorRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CollaboratorRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.salespilot.api.infrastructure.persistence.jpa.repository;
 import com.salespilot.api.application.exception.CollaboratorNotFoundException;
 import com.salespilot.api.domain.entity.Collaborator;
 import com.salespilot.api.domain.enums.CollaboratorRole;
+import com.salespilot.api.domain.model.StatusCount;
 import com.salespilot.api.domain.repository.CollaboratorRepository;
 import com.salespilot.api.domain.valueobject.CollaboratorPreferences;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.CollaboratorEntity;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -165,5 +167,14 @@ public class CollaboratorRepositoryImpl implements CollaboratorRepository {
                 false,
                 period
         );
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<StatusCount> countSellersGroupedByStatus() {
+        return collaboratorJpaRepository.countSellersGroupedByStatus()
+                .stream()
+                .map(item -> new StatusCount((Boolean) item[0], ((Number) item[1]).longValue()))
+                .toList();
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImpl.java
@@ -1,18 +1,7 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.salespilot.api.domain.entity.Company;
-import com.salespilot.api.domain.model.CompanyStatusCount;
+import com.salespilot.api.domain.model.StatusCount;
 import com.salespilot.api.domain.repository.CompanyRepository;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.CompanyEntity;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.CompanyStatusHistoryEntity;
@@ -21,6 +10,16 @@ import com.salespilot.api.infrastructure.persistence.jpa.entity.SubscriptionPlan
 import com.salespilot.api.infrastructure.persistence.jpa.mapper.CompanyMapper;
 import com.salespilot.api.infrastructure.persistence.jpa.specification.CompanySpecification;
 import com.salespilot.api.model.CompanyNameAndTotalMeetings;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 public class CompanyRepositoryImpl implements CompanyRepository {
@@ -154,7 +153,7 @@ public class CompanyRepositoryImpl implements CompanyRepository {
     
     @Transactional(readOnly = true)
     @Override
-    public List<CompanyStatusCount> countCompaniesGroupedByStatus() {
+    public List<StatusCount> countCompaniesGroupedByStatus() {
         return companyJpaRepository
             .countCompaniesGroupedByStatus()
             .stream()
@@ -162,7 +161,7 @@ public class CompanyRepositoryImpl implements CompanyRepository {
             .toList();
     }
 
-    private CompanyStatusCount mapToCompanyStatusCount(Object[] item) {
+    private StatusCount mapToCompanyStatusCount(Object[] item) {
         if (item == null || item.length < 2) {
             throw new IllegalStateException("Resultado inválido da query de companies");
         }
@@ -170,7 +169,7 @@ public class CompanyRepositoryImpl implements CompanyRepository {
         Boolean active = (Boolean) item[0];
         Number total = (Number) item[1];
 
-        return new CompanyStatusCount(
+        return new StatusCount(
             Boolean.TRUE.equals(active),
             total.longValue()
         );

--- a/infrastructure/src/test/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImplTest.java
+++ b/infrastructure/src/test/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CompanyRepositoryImplTest.java
@@ -1,7 +1,7 @@
 package com.salespilot.api.infrastructure.persistence.jpa.repository;
 
 import com.salespilot.api.domain.entity.Company;
-import com.salespilot.api.domain.model.CompanyStatusCount;
+import com.salespilot.api.domain.model.StatusCount;
 import com.salespilot.api.infrastructure.InfrastructureTestApplication;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.CompanyEntity;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.SubscriptionPlans;
@@ -158,7 +158,7 @@ class CompanyRepositoryImplTest {
         companyJpaRepository.saveAndFlush(new CompanyEntity("Active Beta", "44.002.002/0001-02", true));
         companyJpaRepository.saveAndFlush(new CompanyEntity("Inactive Gamma", "44.003.003/0001-03", false));
 
-        List<CompanyStatusCount> result = companyRepository.countCompaniesGroupedByStatus();
+        List<StatusCount> result = companyRepository.countCompaniesGroupedByStatus();
 
         assertThat(result).isNotEmpty();
         assertThat(result).anyMatch(entry -> entry.active() && entry.total() >= 2);

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
@@ -4,12 +4,13 @@ import com.salespilot.api.application.dto.AdminGroupCardMetricsResponseDTO;
 import com.salespilot.api.application.dto.AuthUserDTO;
 import com.salespilot.api.application.dto.GroupAverageMeetingDurationPerMonthResponseDTO;
 import com.salespilot.api.application.dto.GroupCardMetricsResponse;
-import com.salespilot.api.application.dto.GroupCompanyCountResponseDTO;
+import com.salespilot.api.application.dto.GroupStatusCountResponseDTO;
 import com.salespilot.api.application.dto.MeetingsGroupedByMonthResponseDTO;
 import com.salespilot.api.application.dto.TopFiveCompanyByMeetingTotalResponseDto;
 import com.salespilot.api.application.usecase.GetAverageMeetingDurationPerMonthUseCase;
 import com.salespilot.api.application.usecase.GetCardMetricsUseCase;
 import com.salespilot.api.application.usecase.GetGroupedCompaniesCountUseCase;
+import com.salespilot.api.application.usecase.GetGroupedSellersCountUseCase;
 import com.salespilot.api.application.usecase.GetTopFiveCompaniesByMeetingTotalUseCase;
 import com.salespilot.api.application.usecase.GetTotalMeetingsGroupedByMonthUseCase;
 import com.salespilot.api.presentation.utils.JwtUtils;
@@ -41,6 +42,7 @@ public class DashboardController {
     private final GetTopFiveCompaniesByMeetingTotalUseCase getTopFiveCompaniesByMeetingTotalUseCase;
     private final GetCardMetricsUseCase getCardMetricsUseCase;
     private final GetAverageMeetingDurationPerMonthUseCase getAverageMeetingDurationPerMonthUseCase;
+    private final GetGroupedSellersCountUseCase getGroupedSellersCountUseCase;
 
     private static final String COMPANY_STATUS_RESPONSE_EXAMPLE = """
             {
@@ -52,12 +54,13 @@ public class DashboardController {
             }
             """;
 
-    public DashboardController(GetTotalMeetingsGroupedByMonthUseCase getTotalMeetingsGroupedByMonth, GetGroupedCompaniesCountUseCase getGroupedCompaniesCountUseCase, GetTopFiveCompaniesByMeetingTotalUseCase getTopFiveCompaniesByMeetingTotalUseCase, GetCardMetricsUseCase getCardMetricsUseCase, GetAverageMeetingDurationPerMonthUseCase getAverageMeetingDurationPerMonthUseCase){
+    public DashboardController(GetTotalMeetingsGroupedByMonthUseCase getTotalMeetingsGroupedByMonth, GetGroupedCompaniesCountUseCase getGroupedCompaniesCountUseCase, GetTopFiveCompaniesByMeetingTotalUseCase getTopFiveCompaniesByMeetingTotalUseCase, GetCardMetricsUseCase getCardMetricsUseCase, GetAverageMeetingDurationPerMonthUseCase getAverageMeetingDurationPerMonthUseCase, GetGroupedSellersCountUseCase getGroupedSellersCountUseCase){
         this.getTotalMeetingsGroupedByMonth = getTotalMeetingsGroupedByMonth;
         this.getGroupedCompaniesCountUseCase = getGroupedCompaniesCountUseCase;
         this.getTopFiveCompaniesByMeetingTotalUseCase = getTopFiveCompaniesByMeetingTotalUseCase;
         this.getCardMetricsUseCase = getCardMetricsUseCase;
         this.getAverageMeetingDurationPerMonthUseCase = getAverageMeetingDurationPerMonthUseCase;
+        this.getGroupedSellersCountUseCase = getGroupedSellersCountUseCase;
     }
 
     @Operation(summary = "Listar reunoões por mês", description = "Retorna uma lista contendo o mês e sua quantidade de reniões a partir de filtros personalizados, 30d, ou 90d.")
@@ -116,12 +119,12 @@ public class DashboardController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Dados retornados com sucesso",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = GroupCompanyCountResponseDTO.class),
+                            schema = @Schema(implementation = GroupStatusCountResponseDTO.class),
                             examples = @ExampleObject(value = COMPANY_STATUS_RESPONSE_EXAMPLE))),
     })
     @PreAuthorize("hasRole('SYSTEM_ADMIN')")
     @GetMapping("/companies-status")
-    public ResponseEntity<GroupCompanyCountResponseDTO> getGroupedCompaniesCount() {
+    public ResponseEntity<GroupStatusCountResponseDTO> getGroupedCompaniesCount() {
         return ResponseEntity.ok(getGroupedCompaniesCountUseCase.execute());
     }
 
@@ -155,5 +158,18 @@ public class DashboardController {
         @RequestParam(name = "end_date", required = false) LocalDate endDate)
     {
         return ResponseEntity.ok(getAverageMeetingDurationPerMonthUseCase.execute(period, startDate, endDate));
+    }
+
+    @Operation(summary = "Retornar vendedores ativos e inativos", description = "Retorna a quantidade de vendedores ativos e inativos")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Dados retornados com sucesso",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = GroupStatusCountResponseDTO.class),
+                            examples = @ExampleObject(value = ""))),
+    })
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    @GetMapping("/sellers-status")
+    public ResponseEntity<GroupStatusCountResponseDTO> getGroupedSellersCount() {
+        return ResponseEntity.ok(getGroupedSellersCountUseCase.execute());
     }
 }

--- a/presentation/src/test/java/com/salespilot/api/presentation/controller/DashboardControllerTest.java
+++ b/presentation/src/test/java/com/salespilot/api/presentation/controller/DashboardControllerTest.java
@@ -4,9 +4,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.salespilot.api.application.dto.*;
+import com.salespilot.api.application.dto.AdminGroupCardMetricsResponseDTO;
+import com.salespilot.api.application.dto.CardMetricsResponseDTO;
+import com.salespilot.api.application.dto.CompanyNameAndTotalMeetingsDto;
+import com.salespilot.api.application.dto.DashboardStatusCountDTO;
+import com.salespilot.api.application.dto.GroupAverageMeetingDurationPerMonthResponseDTO;
+import com.salespilot.api.application.dto.GroupStatusCountResponseDTO;
+import com.salespilot.api.application.dto.MeetingsGroupedByMonthResponseDTO;
+import com.salespilot.api.application.dto.TopFiveCompanyByMeetingTotalResponseDto;
 import com.salespilot.api.application.exception.InvalidPeriodException;
-import com.salespilot.api.application.usecase.*;
+import com.salespilot.api.application.usecase.GetAverageMeetingDurationPerMonthUseCase;
+import com.salespilot.api.application.usecase.GetCardMetricsUseCase;
+import com.salespilot.api.application.usecase.GetGroupedCompaniesCountUseCase;
+import com.salespilot.api.application.usecase.GetGroupedSellersCountUseCase;
+import com.salespilot.api.application.usecase.GetTopFiveCompaniesByMeetingTotalUseCase;
+import com.salespilot.api.application.usecase.GetTotalMeetingsGroupedByMonthUseCase;
 import com.salespilot.api.presentation.handler.GlobalExceptionHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +44,8 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 class DashboardControllerTest {
@@ -44,6 +57,8 @@ class DashboardControllerTest {
     @Mock GetTopFiveCompaniesByMeetingTotalUseCase getTopFiveCompaniesByMeetingTotalUseCase;
     @Mock GetCardMetricsUseCase getCardMetricsUseCase;
     @Mock GetAverageMeetingDurationPerMonthUseCase getAverageMeetingDurationPerMonthUseCase;
+    @Mock
+    GetGroupedSellersCountUseCase getGroupedSellersCountUseCase;
 
     @InjectMocks
     DashboardController controller;
@@ -107,8 +122,8 @@ class DashboardControllerTest {
     @Test
     void shouldGetCompaniesStatusAndReturn200() throws Exception {
         when(getGroupedCompaniesCountUseCase.execute())
-                .thenReturn(new GroupCompanyCountResponseDTO(
-                        List.of(new CompanyStatusCountDTO("Ativas", 5L)), 5L));
+                .thenReturn(new GroupStatusCountResponseDTO(
+                        List.of(new DashboardStatusCountDTO("Ativas", 5L)), 5L));
 
         mockMvc.perform(get("/api/dashboard/companies-status"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## Issue relacionada

N/A

## O que foi implementado?

Foi adicionada a contagem de sellers ativos e inativos para o dashboard, alterando DTOs e model que já existiam para fazer isso para as companies no /api/dashboard/companies-status (tornando eles mais genéricos).

## Por que essa mudança é necessária?

É uma função necessária na aplicação.

## Como testar?

acessar com GET os endpoints:

http://localhost:8080/api/dashboard/sellers-status
http://localhost:8080/api/dashboard/companies-status

e verificar se os valores batem com aqueles inseridos no banco.

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças

<img width="1492" height="982" alt="image" src="https://github.com/user-attachments/assets/321e2508-8c70-41dc-9358-743688e1a064" />

<img width="1454" height="1063" alt="image" src="https://github.com/user-attachments/assets/95aedb4d-a6c8-40c5-b8cb-8cd77b0514f0" />

obs: nesses testes não utilizei os útlimos dados adicionados no banco, então provavelmente os números serão diferentes.