### PR TITLE
feat(dashboard): add meetings by seller endpoint

### DIFF
--- a/application/src/main/java/com/salespilot/api/application/dto/MeetingsBySellerResponseDto.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/MeetingsBySellerResponseDto.java
@@ -1,0 +1,8 @@
+package com.salespilot.api.application.dto;
+
+import java.util.List;
+
+public record MeetingsBySellerResponseDto(
+    List<SellerNameAndTotalMeetingsDto> data
+) {
+}

--- a/application/src/main/java/com/salespilot/api/application/dto/SellerNameAndTotalMeetingsDto.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/SellerNameAndTotalMeetingsDto.java
@@ -1,0 +1,7 @@
+package com.salespilot.api.application.dto;
+
+public record SellerNameAndTotalMeetingsDto(
+    String sellerName,
+    Long total
+) {
+}

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetMeetingsBySellerUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetMeetingsBySellerUseCase.java
@@ -1,0 +1,33 @@
+package com.salespilot.api.application.usecase;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.salespilot.api.application.dto.MeetingsBySellerResponseDto;
+import com.salespilot.api.application.dto.SellerNameAndTotalMeetingsDto;
+import com.salespilot.api.application.utils.DashboardPeriodUtils;
+import com.salespilot.api.domain.repository.CollaboratorRepository;
+import com.salespilot.api.model.SellerNameAndTotalMeetings;
+
+public class GetMeetingsBySellerUseCase {
+    private final CollaboratorRepository collaboratorRepository;
+
+    public GetMeetingsBySellerUseCase(CollaboratorRepository collaboratorRepository){
+        this.collaboratorRepository = collaboratorRepository;
+    }
+
+    public MeetingsBySellerResponseDto execute(String period, LocalDate start, LocalDate end){
+        LocalDateTime[] range = DashboardPeriodUtils.resolve(period, start, end);
+
+        LocalDateTime startDate = range[0];
+        LocalDateTime endDate = range[1];
+
+        List<SellerNameAndTotalMeetingsDto> data = collaboratorRepository.getMeetingsBySeller(startDate, endDate).stream().map(this::map).toList();
+        return new MeetingsBySellerResponseDto(data);
+    }
+
+    private SellerNameAndTotalMeetingsDto map(SellerNameAndTotalMeetings item) {
+        return new SellerNameAndTotalMeetingsDto(item.sellerName(), item.total());
+    }
+}

--- a/domain/src/main/java/com/salespilot/api/domain/repository/CollaboratorRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/CollaboratorRepository.java
@@ -4,6 +4,7 @@ import com.salespilot.api.domain.entity.Collaborator;
 import com.salespilot.api.domain.enums.CollaboratorRole;
 import com.salespilot.api.domain.model.StatusCount;
 import com.salespilot.api.domain.valueobject.CollaboratorPreferences;
+import com.salespilot.api.model.SellerNameAndTotalMeetings;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -26,4 +27,5 @@ public interface CollaboratorRepository {
     Long countActiveSellersByCompanyIdAndPeriod(UUID companyId, LocalDateTime period);
     Long countInactiveSellersByCompanyIdAndPeriod(UUID companyId, LocalDateTime period);
     List<StatusCount> countSellersGroupedByStatus();
+    List<SellerNameAndTotalMeetings> getMeetingsBySeller(LocalDateTime start, LocalDateTime end);
 }

--- a/domain/src/main/java/com/salespilot/api/model/SellerNameAndTotalMeetings.java
+++ b/domain/src/main/java/com/salespilot/api/model/SellerNameAndTotalMeetings.java
@@ -1,0 +1,7 @@
+package com.salespilot.api.model;
+
+public record SellerNameAndTotalMeetings(
+    String sellerName,
+    Long total
+) {
+}

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
@@ -24,6 +24,7 @@ import com.salespilot.api.application.usecase.GetGroupedSellersCountUseCase;
 import com.salespilot.api.application.usecase.GetMeetingContextAndMetadataUseCase;
 import com.salespilot.api.application.usecase.GetMeetingInsightUseCase;
 import com.salespilot.api.application.usecase.GetMeetingPostAnalysisUseCase;
+import com.salespilot.api.application.usecase.GetMeetingsBySellerUseCase;
 import com.salespilot.api.application.usecase.GetSellerByIdUseCase;
 import com.salespilot.api.application.usecase.GetSystemStatusUseCase;
 import com.salespilot.api.application.usecase.GetTopFiveCompaniesByMeetingTotalUseCase;
@@ -154,5 +155,10 @@ public class UseCaseConfig {
     @Bean
     public GetGroupedSellersCountUseCase getGroupedSellersCountUseCase(CollaboratorRepository collaboratorRepository) {
         return new GetGroupedSellersCountUseCase(collaboratorRepository);
+    }
+
+    @Bean
+    public GetMeetingsBySellerUseCase getMeetingsBySellerUseCase(CollaboratorRepository collaboratorRepository) {
+        return new GetMeetingsBySellerUseCase(collaboratorRepository);
     }
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CollaboratorJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CollaboratorJpaRepository.java
@@ -4,7 +4,9 @@ import com.salespilot.api.infrastructure.persistence.jpa.entity.CollaboratorEnti
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -20,4 +22,18 @@ public interface CollaboratorJpaRepository extends JpaRepository<CollaboratorEnt
     GROUP BY c.active
 """)
     List<Object[]> countSellersGroupedByStatus();
+
+    @Query(value = """
+        SELECT
+            col.name AS seller_name,
+            COUNT(m.id) AS total
+        FROM collaborators col
+        LEFT JOIN meetings m
+            ON m.collaborator_id = col.id
+            AND m.created_at BETWEEN :start AND :end
+        WHERE col.role = 'SELLER'
+        GROUP BY col.id, col.name
+        ORDER BY total DESC, col.name ASC
+    """, nativeQuery = true)
+    List<Object[]> getMeetingsBySeller(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CollaboratorRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CollaboratorRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.salespilot.api.domain.enums.CollaboratorRole;
 import com.salespilot.api.domain.model.StatusCount;
 import com.salespilot.api.domain.repository.CollaboratorRepository;
 import com.salespilot.api.domain.valueobject.CollaboratorPreferences;
+import com.salespilot.api.model.SellerNameAndTotalMeetings;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.CollaboratorEntity;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.CollaboratorStatusHistoryEntity;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.CompanyEntity;
@@ -176,5 +177,18 @@ public class CollaboratorRepositoryImpl implements CollaboratorRepository {
                 .stream()
                 .map(item -> new StatusCount((Boolean) item[0], ((Number) item[1]).longValue()))
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<SellerNameAndTotalMeetings> getMeetingsBySeller(LocalDateTime start, LocalDateTime end) {
+        return collaboratorJpaRepository.getMeetingsBySeller(start, end).stream().map(this::mapToSellerNameAndTotalMeetings).toList();
+    }
+
+    private SellerNameAndTotalMeetings mapToSellerNameAndTotalMeetings(Object[] item) {
+        String name = item[0].toString();
+        Long total = ((Number) item[1]).longValue();
+
+        return new SellerNameAndTotalMeetings(name, total);
     }
 }

--- a/infrastructure/src/test/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CollaboratorRepositoryImplTest.java
+++ b/infrastructure/src/test/java/com/salespilot/api/infrastructure/persistence/jpa/repository/CollaboratorRepositoryImplTest.java
@@ -3,7 +3,11 @@ package com.salespilot.api.infrastructure.persistence.jpa.repository;
 import com.salespilot.api.domain.entity.Collaborator;
 import com.salespilot.api.domain.enums.CollaboratorRole;
 import com.salespilot.api.infrastructure.InfrastructureTestApplication;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.ClientEntity;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.CollaboratorEntity;
 import com.salespilot.api.infrastructure.persistence.jpa.entity.CompanyEntity;
+import com.salespilot.api.infrastructure.persistence.jpa.entity.MeetingEntity;
+import com.salespilot.api.model.SellerNameAndTotalMeetings;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,6 +21,8 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -57,12 +63,39 @@ class CollaboratorRepositoryImplTest {
     @Autowired
     CollaboratorJpaRepository collaboratorJpaRepository;
 
+    @Autowired
+    ClientsJpaRepository clientsJpaRepository;
+
+    @Autowired
+    MeetingsJpaRepository meetingsJpaRepository;
+
     // ---------------------------------------------------------------------------
     // Helper
     // ---------------------------------------------------------------------------
 
     private CompanyEntity createCompany(String taxId) {
         return companyJpaRepository.saveAndFlush(new CompanyEntity("Test Corp", taxId, true));
+    }
+
+    private ClientEntity createClient(CompanyEntity company, CollaboratorEntity seller) {
+        ClientEntity client = new ClientEntity();
+        client.setId(UUID.randomUUID());
+        client.setCompany(company);
+        client.setCollaborator(seller);
+        client.setName("Client of " + seller.getName());
+        client.setCreatedAt(LocalDateTime.now());
+        client.setUpdatedAt(LocalDateTime.now());
+        return clientsJpaRepository.saveAndFlush(client);
+    }
+
+    private void createMeeting(CollaboratorEntity seller, ClientEntity client) {
+        MeetingEntity meeting = new MeetingEntity();
+        meeting.setId(UUID.randomUUID());
+        meeting.setCollaborator(seller);
+        meeting.setClient(client);
+        meeting.setStatus("COMPLETED");
+        meeting.setCreatedAt(LocalDateTime.now());
+        meetingsJpaRepository.saveAndFlush(meeting);
     }
 
     // ---------------------------------------------------------------------------
@@ -254,6 +287,50 @@ class CollaboratorRepositoryImplTest {
         assertThat(found.get().getName()).isEqualTo("Updated Name");
         assertThat(found.get().getEmail()).isEqualTo("updated@test.com");
         assertThat(found.get().getPhone()).isEqualTo("11999999999");
+    }
+
+    @Test
+    void shouldReturnMeetingsBySellerOrderedByTotalDesc() {
+        CompanyEntity company = createCompany("99.111.111/0009-99");
+
+        Collaborator topSeller = collaboratorRepository.create(
+                company.getId(), "Top Seller", "top.seller@test.com", CollaboratorRole.SELLER, true, null, null);
+        Collaborator lowSeller = collaboratorRepository.create(
+                company.getId(), "Low Seller", "low.seller@test.com", CollaboratorRole.SELLER, true, null, null);
+        collaboratorRepository.create(
+                company.getId(), "Some Manager", "some.manager@test.com", CollaboratorRole.MANAGER, true, null, null);
+
+        CollaboratorEntity topSellerEntity = collaboratorJpaRepository.getReferenceById(topSeller.getId());
+        CollaboratorEntity lowSellerEntity = collaboratorJpaRepository.getReferenceById(lowSeller.getId());
+
+        ClientEntity topClient = createClient(company, topSellerEntity);
+        ClientEntity lowClient = createClient(company, lowSellerEntity);
+
+        createMeeting(topSellerEntity, topClient);
+        createMeeting(topSellerEntity, topClient);
+        createMeeting(lowSellerEntity, lowClient);
+
+        List<SellerNameAndTotalMeetings> result = collaboratorRepository.getMeetingsBySeller(
+                LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1));
+
+        assertThat(result).extracting(SellerNameAndTotalMeetings::sellerName)
+                .containsExactly("Top Seller", "Low Seller");
+        assertThat(result.get(0).total()).isEqualTo(2L);
+        assertThat(result.get(1).total()).isEqualTo(1L);
+        assertThat(result).noneMatch(item -> item.sellerName().equals("Some Manager"));
+    }
+
+    @Test
+    void shouldReturnSellersWithZeroMeetingsWhenNoneInPeriod() {
+        CompanyEntity company = createCompany("99.222.222/0010-99");
+
+        collaboratorRepository.create(
+                company.getId(), "Idle Seller", "idle.seller@test.com", CollaboratorRole.SELLER, true, null, null);
+
+        List<SellerNameAndTotalMeetings> result = collaboratorRepository.getMeetingsBySeller(
+                LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1));
+
+        assertThat(result).anyMatch(item -> item.sellerName().equals("Idle Seller") && item.total() == 0L);
     }
 
     @Test

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
@@ -5,12 +5,14 @@ import com.salespilot.api.application.dto.AuthUserDTO;
 import com.salespilot.api.application.dto.GroupAverageMeetingDurationPerMonthResponseDTO;
 import com.salespilot.api.application.dto.GroupCardMetricsResponse;
 import com.salespilot.api.application.dto.GroupStatusCountResponseDTO;
+import com.salespilot.api.application.dto.MeetingsBySellerResponseDto;
 import com.salespilot.api.application.dto.MeetingsGroupedByMonthResponseDTO;
 import com.salespilot.api.application.dto.TopFiveCompanyByMeetingTotalResponseDto;
 import com.salespilot.api.application.usecase.GetAverageMeetingDurationPerMonthUseCase;
 import com.salespilot.api.application.usecase.GetCardMetricsUseCase;
 import com.salespilot.api.application.usecase.GetGroupedCompaniesCountUseCase;
 import com.salespilot.api.application.usecase.GetGroupedSellersCountUseCase;
+import com.salespilot.api.application.usecase.GetMeetingsBySellerUseCase;
 import com.salespilot.api.application.usecase.GetTopFiveCompaniesByMeetingTotalUseCase;
 import com.salespilot.api.application.usecase.GetTotalMeetingsGroupedByMonthUseCase;
 import com.salespilot.api.presentation.utils.JwtUtils;
@@ -43,6 +45,7 @@ public class DashboardController {
     private final GetCardMetricsUseCase getCardMetricsUseCase;
     private final GetAverageMeetingDurationPerMonthUseCase getAverageMeetingDurationPerMonthUseCase;
     private final GetGroupedSellersCountUseCase getGroupedSellersCountUseCase;
+    private final GetMeetingsBySellerUseCase getMeetingsBySellerUseCase;
 
     private static final String COMPANY_STATUS_RESPONSE_EXAMPLE = """
             {
@@ -54,13 +57,14 @@ public class DashboardController {
             }
             """;
 
-    public DashboardController(GetTotalMeetingsGroupedByMonthUseCase getTotalMeetingsGroupedByMonth, GetGroupedCompaniesCountUseCase getGroupedCompaniesCountUseCase, GetTopFiveCompaniesByMeetingTotalUseCase getTopFiveCompaniesByMeetingTotalUseCase, GetCardMetricsUseCase getCardMetricsUseCase, GetAverageMeetingDurationPerMonthUseCase getAverageMeetingDurationPerMonthUseCase, GetGroupedSellersCountUseCase getGroupedSellersCountUseCase){
+    public DashboardController(GetTotalMeetingsGroupedByMonthUseCase getTotalMeetingsGroupedByMonth, GetGroupedCompaniesCountUseCase getGroupedCompaniesCountUseCase, GetTopFiveCompaniesByMeetingTotalUseCase getTopFiveCompaniesByMeetingTotalUseCase, GetCardMetricsUseCase getCardMetricsUseCase, GetAverageMeetingDurationPerMonthUseCase getAverageMeetingDurationPerMonthUseCase, GetGroupedSellersCountUseCase getGroupedSellersCountUseCase, GetMeetingsBySellerUseCase getMeetingsBySellerUseCase){
         this.getTotalMeetingsGroupedByMonth = getTotalMeetingsGroupedByMonth;
         this.getGroupedCompaniesCountUseCase = getGroupedCompaniesCountUseCase;
         this.getTopFiveCompaniesByMeetingTotalUseCase = getTopFiveCompaniesByMeetingTotalUseCase;
         this.getCardMetricsUseCase = getCardMetricsUseCase;
         this.getAverageMeetingDurationPerMonthUseCase = getAverageMeetingDurationPerMonthUseCase;
         this.getGroupedSellersCountUseCase = getGroupedSellersCountUseCase;
+        this.getMeetingsBySellerUseCase = getMeetingsBySellerUseCase;
     }
 
     @Operation(summary = "Listar reunoões por mês", description = "Retorna uma lista contendo o mês e sua quantidade de reniões a partir de filtros personalizados, 30d, ou 90d.")
@@ -113,6 +117,30 @@ public class DashboardController {
         @RequestParam(name = "start_date", required = false) LocalDate startDate,
         @RequestParam(name = "end_date", required = false) LocalDate endDate) {
         return ResponseEntity.ok(getTopFiveCompaniesByMeetingTotalUseCase.execute(period, startDate, endDate));
+    }
+
+    @Operation(summary = "Listar reuniões por vendedor", description = "Retorna uma lista contendo o nome do vendedor e a quantidade de reuniões, em ordem decrescente de reuniões, de todo período ou intervalo de datas personalizadas")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso",
+            content = @Content(mediaType = "application/json",
+                    examples = @ExampleObject(value = """
+                            {
+                                "data": [
+                                    { "seller_name": "Ana Silva", "total": 18 },
+                                    { "seller_name": "Saulo Souza", "total": 12 },
+                                    { "seller_name": "Carlos Lima", "total": 0 }
+                                ]
+                            }
+                            """))),
+        @ApiResponse(responseCode = "400", description = "Parâmetros 'start_date' ou 'end_date' inválidos")
+    })
+    @PreAuthorize("hasAnyRole('SYSTEM_ADMIN', 'MANAGER')")
+    @GetMapping("/meetings-by-seller")
+    public ResponseEntity<MeetingsBySellerResponseDto> getMeetingsBySeller(
+        @RequestParam(required = true) String period,
+        @RequestParam(name = "start_date", required = false) LocalDate startDate,
+        @RequestParam(name = "end_date", required = false) LocalDate endDate) {
+        return ResponseEntity.ok(getMeetingsBySellerUseCase.execute(period, startDate, endDate));
     }
 
     @Operation(summary = "Retornar empresas ativas e inativas", description = "Retorna a quantidade de empresas ativas e inativas")

--- a/presentation/src/test/java/com/salespilot/api/presentation/controller/DashboardControllerTest.java
+++ b/presentation/src/test/java/com/salespilot/api/presentation/controller/DashboardControllerTest.java
@@ -10,13 +10,16 @@ import com.salespilot.api.application.dto.CompanyNameAndTotalMeetingsDto;
 import com.salespilot.api.application.dto.DashboardStatusCountDTO;
 import com.salespilot.api.application.dto.GroupAverageMeetingDurationPerMonthResponseDTO;
 import com.salespilot.api.application.dto.GroupStatusCountResponseDTO;
+import com.salespilot.api.application.dto.MeetingsBySellerResponseDto;
 import com.salespilot.api.application.dto.MeetingsGroupedByMonthResponseDTO;
+import com.salespilot.api.application.dto.SellerNameAndTotalMeetingsDto;
 import com.salespilot.api.application.dto.TopFiveCompanyByMeetingTotalResponseDto;
 import com.salespilot.api.application.exception.InvalidPeriodException;
 import com.salespilot.api.application.usecase.GetAverageMeetingDurationPerMonthUseCase;
 import com.salespilot.api.application.usecase.GetCardMetricsUseCase;
 import com.salespilot.api.application.usecase.GetGroupedCompaniesCountUseCase;
 import com.salespilot.api.application.usecase.GetGroupedSellersCountUseCase;
+import com.salespilot.api.application.usecase.GetMeetingsBySellerUseCase;
 import com.salespilot.api.application.usecase.GetTopFiveCompaniesByMeetingTotalUseCase;
 import com.salespilot.api.application.usecase.GetTotalMeetingsGroupedByMonthUseCase;
 import com.salespilot.api.presentation.handler.GlobalExceptionHandler;
@@ -59,6 +62,8 @@ class DashboardControllerTest {
     @Mock GetAverageMeetingDurationPerMonthUseCase getAverageMeetingDurationPerMonthUseCase;
     @Mock
     GetGroupedSellersCountUseCase getGroupedSellersCountUseCase;
+    @Mock
+    GetMeetingsBySellerUseCase getMeetingsBySellerUseCase;
 
     @InjectMocks
     DashboardController controller;
@@ -117,6 +122,27 @@ class DashboardControllerTest {
         mockMvc.perform(get("/api/dashboard/meetings-by-company?period=all"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].company_name").value("Acme"));
+    }
+
+    @Test
+    void shouldGetMeetingsBySellerAndReturn200() throws Exception {
+        when(getMeetingsBySellerUseCase.execute(any(), any(), any()))
+                .thenReturn(new MeetingsBySellerResponseDto(
+                        List.of(new SellerNameAndTotalMeetingsDto("Ana Silva", 18L))));
+
+        mockMvc.perform(get("/api/dashboard/meetings-by-seller?period=all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].seller_name").value("Ana Silva"))
+                .andExpect(jsonPath("$.data[0].total").value(18));
+    }
+
+    @Test
+    void shouldReturn400WhenInvalidPeriodOnMeetingsBySeller() throws Exception {
+        when(getMeetingsBySellerUseCase.execute(any(), any(), any()))
+                .thenThrow(new InvalidPeriodException(null, null));
+
+        mockMvc.perform(get("/api/dashboard/meetings-by-seller?period=invalid"))
+                .andExpect(status().isBadRequest());
     }
 
     @Test


### PR DESCRIPTION
## Issue relacionada

<!-- Link da issue no GitHub. -->
Demanda do time: criar rota de GET de reuniões por vendedor (gráfico do dashboard).

## O que foi implementado?

Novo endpoint `GET /api/dashboard/meetings-by-seller`, que retorna a quantidade de reuniões por vendedor, em ordem decrescente de total, para alimentar o gráfico de **reuniões por vendedor** do dashboard.

- Aceita o parâmetro `period` (`all`, `30d`, `90d`, `custom`) e, no modo `custom`, `start_date`/`end_date` — mesmo contrato de período já usado em `meetings-by-company` e `meetings-by-month`.
- Vendedores **sem reuniões** no período aparecem com `total: 0` (`LEFT JOIN`), para que o gráfico mostre toda a equipe e não só quem teve reunião.
- Acesso restrito a `SYSTEM_ADMIN` e `MANAGER`, seguindo o mesmo `@PreAuthorize` de `meetings-by-company`.

Camadas seguindo o padrão do projeto (espelhando `GetTopFiveCompaniesByMeetingTotalUseCase`):
- `model/SellerNameAndTotalMeetings` (domain)
- `dto/SellerNameAndTotalMeetingsDto`, `dto/MeetingsBySellerResponseDto` (application)
- `usecase/GetMeetingsBySellerUseCase` (application)
- método `getMeetingsBySeller` em `CollaboratorRepository` + native query em `CollaboratorJpaRepository` + impl em `CollaboratorRepositoryImpl`
- bean em `UseCaseConfig`
- endpoint + Swagger em `DashboardController`

Exemplo de resposta:

```json
{
  "data": [
    { "seller_name": "Ana Silva", "total": 18 },
    { "seller_name": "Saulo Souza", "total": 12 },
    { "seller_name": "Carlos Lima", "total": 0 }
  ]
}
```

## Por que essa mudança é necessária?

O frontend precisa do gráfico de reuniões por vendedor no dashboard e não existia rota no backend que agregasse reuniões por vendedor — só por empresa (`meetings-by-company`). Sem este endpoint a integração do gráfico ficava bloqueada.

## Como testar?

1. Autenticar como `SYSTEM_ADMIN` ou `MANAGER`.
2. `GET /api/dashboard/meetings-by-seller?period=all`
3. `GET /api/dashboard/meetings-by-seller?period=30d`
4. `GET /api/dashboard/meetings-by-seller?period=custom&start_date=2026-01-01&end_date=2026-06-30`
5. Conferir que a lista vem ordenada por `total` desc e que vendedores sem reuniões no período aparecem com `total: 0`.
6. `period` inválido deve retornar `400`.

Testes automatizados:
- `DashboardControllerTest`: status 200 + payload e 400 em período inválido.
- `CollaboratorRepositoryImplTest`: ordenação por total desc, exclusão de não-vendedores e vendedor com 0 reuniões.

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [x] Testes foram adicionados ou atualizados para cobrir as mudanças
