### PR TITLE
feat(dashboard): add average sentiment to seller metrics

### DIFF
--- a/application/src/main/java/com/salespilot/api/application/dto/SellerGroupCardMetricsResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/SellerGroupCardMetricsResponseDTO.java
@@ -2,5 +2,6 @@ package com.salespilot.api.application.dto;
 
 public record SellerGroupCardMetricsResponseDTO(
     CardMetricsResponseDTO totalMeetings,
-    CardMetricsResponseDTO averageDuration
+    CardMetricsResponseDTO averageDuration,
+    SentimentCardMetricsResponseDTO averageSentiment
 ) implements GroupCardMetricsResponse {}

--- a/application/src/main/java/com/salespilot/api/application/dto/SentimentCardMetricsResponseDTO.java
+++ b/application/src/main/java/com/salespilot/api/application/dto/SentimentCardMetricsResponseDTO.java
@@ -1,0 +1,7 @@
+package com.salespilot.api.application.dto;
+
+public record SentimentCardMetricsResponseDTO(
+    Double value,
+    Double variationPercent,
+    String trend
+) {}

--- a/application/src/main/java/com/salespilot/api/application/usecase/GetCardMetricsUseCase.java
+++ b/application/src/main/java/com/salespilot/api/application/usecase/GetCardMetricsUseCase.java
@@ -6,10 +6,12 @@ import com.salespilot.api.application.dto.CardMetricsResponseDTO;
 import com.salespilot.api.application.dto.GroupCardMetricsResponse;
 import com.salespilot.api.application.dto.ManagerGroupCardMetricsResponseDTO;
 import com.salespilot.api.application.dto.SellerGroupCardMetricsResponseDTO;
+import com.salespilot.api.application.dto.SentimentCardMetricsResponseDTO;
 import com.salespilot.api.application.utils.DashboardPeriodUtils;
 import com.salespilot.api.domain.enums.MetricsTrends;
 import com.salespilot.api.domain.repository.CollaboratorRepository;
 import com.salespilot.api.domain.repository.CompanyRepository;
+import com.salespilot.api.domain.repository.MeetingPostAnalysisRepository;
 import com.salespilot.api.domain.repository.MeetingRepository;
 
 import java.time.LocalDate;
@@ -20,11 +22,13 @@ public class GetCardMetricsUseCase {
     private final CompanyRepository companyRepository;
     private final MeetingRepository meetingRepository;
     private final CollaboratorRepository collaboratorRepository;
+    private final MeetingPostAnalysisRepository meetingPostAnalysisRepository;
 
-    public GetCardMetricsUseCase(CompanyRepository companyRepository, MeetingRepository meetingRepository, CollaboratorRepository collaboratorRepository) {
+    public GetCardMetricsUseCase(CompanyRepository companyRepository, MeetingRepository meetingRepository, CollaboratorRepository collaboratorRepository, MeetingPostAnalysisRepository meetingPostAnalysisRepository) {
         this.companyRepository = companyRepository;
         this.meetingRepository = meetingRepository;
         this.collaboratorRepository = collaboratorRepository;
+        this.meetingPostAnalysisRepository = meetingPostAnalysisRepository;
     }
 
     public GroupCardMetricsResponse execute(String period, LocalDate startDate, LocalDate endDate, AuthUserDTO authUser) {
@@ -49,6 +53,14 @@ public class GetCardMetricsUseCase {
         }
     }
 
+    private Double calculateVariationPercent(Double previous, Double current) {
+        if (previous == 0.0) {
+            return current > 0.0 ? 100.0 : 0.0;
+        } else {
+            return ((current - previous) / previous) * 100.0;
+        }
+    }
+
     private MetricsTrends getTrendFromVariationPercent(Double variationPercent) {
         if (variationPercent == 0) {
             return MetricsTrends.NEUTRAL;
@@ -61,6 +73,14 @@ public class GetCardMetricsUseCase {
         Double variation = calculateVariationPercent(previous, current);
         MetricsTrends trend = getTrendFromVariationPercent(variation);
         return new CardMetricsResponseDTO(current, variation, trend.getValue());
+    }
+
+    private SentimentCardMetricsResponseDTO buildSentimentCard(Double current, Double previous) {
+        Double safeCurrent = current != null ? current : 0.0;
+        Double safePrevious = previous != null ? previous : 0.0;
+        Double variation = calculateVariationPercent(safePrevious, safeCurrent);
+        MetricsTrends trend = getTrendFromVariationPercent(variation);
+        return new SentimentCardMetricsResponseDTO(safeCurrent, variation, trend.getValue());
     }
 
     private AdminGroupCardMetricsResponseDTO buildAdminGroupCard(LocalDateTime previousStart, LocalDateTime previousEnd, LocalDateTime currentStart, LocalDateTime currentEnd) {
@@ -112,9 +132,14 @@ public class GetCardMetricsUseCase {
 
         Long previousAverageDuration = Math.round(meetingRepository.getAverageDurationByCollaboratorIdAndPeriod(sellerId, previousStart, previousEnd));
 
+        Double currentAverageSentiment = meetingPostAnalysisRepository.getAverageFeelingByCollaboratorAndPeriod(sellerId, currentStart, currentEnd);
+
+        Double previousAverageSentiment = meetingPostAnalysisRepository.getAverageFeelingByCollaboratorAndPeriod(sellerId, previousStart, previousEnd);
+
         return new SellerGroupCardMetricsResponseDTO(
                 buildMetricCard(currentMeetings, previousMeetings),
-                buildMetricCard(currentAverageDuration, previousAverageDuration)
+                buildMetricCard(currentAverageDuration, previousAverageDuration),
+                buildSentimentCard(currentAverageSentiment, previousAverageSentiment)
         );
     }
 }

--- a/application/src/test/java/com/salespilot/api/application/usecase/GetCardMetricsUseCaseTest.java
+++ b/application/src/test/java/com/salespilot/api/application/usecase/GetCardMetricsUseCaseTest.java
@@ -8,6 +8,7 @@ import com.salespilot.api.application.dto.SellerGroupCardMetricsResponseDTO;
 import com.salespilot.api.domain.enums.CollaboratorRole;
 import com.salespilot.api.domain.repository.CollaboratorRepository;
 import com.salespilot.api.domain.repository.CompanyRepository;
+import com.salespilot.api.domain.repository.MeetingPostAnalysisRepository;
 import com.salespilot.api.domain.repository.MeetingRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +39,9 @@ class GetCardMetricsUseCaseTest {
 
     @Mock
     private CollaboratorRepository collaboratorRepository;
+
+    @Mock
+    private MeetingPostAnalysisRepository meetingPostAnalysisRepository;
 
     @InjectMocks
     private GetCardMetricsUseCase useCase;
@@ -89,6 +93,39 @@ class GetCardMetricsUseCaseTest {
         GroupCardMetricsResponse result = useCase.execute("30d", null, null, authUser);
 
         assertInstanceOf(SellerGroupCardMetricsResponseDTO.class, result);
+    }
+
+    @Test
+    void shouldIncludeAverageSentimentCard_whenSeller() {
+        AuthUserDTO authUser = new AuthUserDTO(CollaboratorRole.SELLER, sellerId, UUID.randomUUID());
+
+        when(meetingRepository.countTotalMeetingsByCollaboratorIdAndPeriod(eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(5L);
+        when(meetingRepository.getAverageDurationByCollaboratorIdAndPeriod(eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(60.0);
+        when(meetingPostAnalysisRepository.getAverageFeelingByCollaboratorAndPeriod(eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(8.0, 4.0);
+
+        GroupCardMetricsResponse result = useCase.execute("30d", null, null, authUser);
+
+        SellerGroupCardMetricsResponseDTO sellerResult = (SellerGroupCardMetricsResponseDTO) result;
+        assertEquals(8.0, sellerResult.averageSentiment().value());
+        assertEquals(100.0, sellerResult.averageSentiment().variationPercent());
+        assertEquals("up", sellerResult.averageSentiment().trend());
+    }
+
+    @Test
+    void shouldDefaultAverageSentimentToZero_whenNoPostAnalysis() {
+        AuthUserDTO authUser = new AuthUserDTO(CollaboratorRole.SELLER, sellerId, UUID.randomUUID());
+
+        when(meetingRepository.countTotalMeetingsByCollaboratorIdAndPeriod(eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(0L);
+        when(meetingRepository.getAverageDurationByCollaboratorIdAndPeriod(eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(0.0);
+        when(meetingPostAnalysisRepository.getAverageFeelingByCollaboratorAndPeriod(eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(null);
+
+        GroupCardMetricsResponse result = useCase.execute("30d", null, null, authUser);
+
+        SellerGroupCardMetricsResponseDTO sellerResult = (SellerGroupCardMetricsResponseDTO) result;
+        assertEquals(0.0, sellerResult.averageSentiment().value());
+        assertEquals("neutral", sellerResult.averageSentiment().trend());
     }
 
     @Test

--- a/domain/src/main/java/com/salespilot/api/domain/repository/MeetingPostAnalysisRepository.java
+++ b/domain/src/main/java/com/salespilot/api/domain/repository/MeetingPostAnalysisRepository.java
@@ -2,6 +2,7 @@ package com.salespilot.api.domain.repository;
 
 import com.salespilot.api.domain.entity.MeetingPostAnalysis;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -9,4 +10,5 @@ public interface MeetingPostAnalysisRepository {
     Optional<MeetingPostAnalysis> findByMeetingId(UUID meetingId);
     Double getAverageSuccessRate();
     Double getAverageFeelingByCollaborator(UUID collaboratorId);
+    Double getAverageFeelingByCollaboratorAndPeriod(UUID collaboratorId, LocalDateTime start, LocalDateTime end);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/config/UseCaseConfig.java
@@ -137,8 +137,8 @@ public class UseCaseConfig {
     }
 
     @Bean
-    public GetCardMetricsUseCase getCardMetricsUseCase(CompanyRepository companyRepository, MeetingRepository meetingRepository, CollaboratorRepository collaboratorRepository) {
-        return new GetCardMetricsUseCase(companyRepository, meetingRepository, collaboratorRepository);
+    public GetCardMetricsUseCase getCardMetricsUseCase(CompanyRepository companyRepository, MeetingRepository meetingRepository, CollaboratorRepository collaboratorRepository, MeetingPostAnalysisRepository meetingPostAnalysisRepository) {
+        return new GetCardMetricsUseCase(companyRepository, meetingRepository, collaboratorRepository, meetingPostAnalysisRepository);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisJpaRepository.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisJpaRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -23,4 +24,14 @@ public interface MeetingPostAnalysisJpaRepository extends JpaRepository<MeetingP
             AND mpa.sentiment_analysis IS NOT NULL
             """, nativeQuery = true)
     Optional<Double> findAverageScoreByCollaboratorId(@Param("collaboratorId") UUID collaboratorId);
+
+    @Query(value = """
+            SELECT AVG(CAST(mpa.sentiment_analysis->>'score' AS DOUBLE PRECISION))
+            FROM meeting_post_analysis mpa
+            JOIN meetings m ON m.id = mpa.meeting_id
+            WHERE m.collaborator_id = :collaboratorId
+            AND m.created_at BETWEEN :start AND :end
+            AND mpa.sentiment_analysis IS NOT NULL
+            """, nativeQuery = true)
+    Optional<Double> findAverageScoreByCollaboratorIdAndPeriod(@Param("collaboratorId") UUID collaboratorId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/salespilot/api/infrastructure/persistence/jpa/repository/MeetingPostAnalysisRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.salespilot.api.domain.repository.MeetingPostAnalysisRepository;
 import com.salespilot.api.infrastructure.persistence.jpa.mapper.MeetingPostAnalysisMapper;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -32,5 +33,10 @@ public class MeetingPostAnalysisRepositoryImpl implements MeetingPostAnalysisRep
     @Override
     public Double getAverageFeelingByCollaborator(UUID collaboratorId) {
         return meetingPostAnalysisJpaRepository.findAverageScoreByCollaboratorId(collaboratorId).orElse(null);
+    }
+
+    @Override
+    public Double getAverageFeelingByCollaboratorAndPeriod(UUID collaboratorId, LocalDateTime start, LocalDateTime end) {
+        return meetingPostAnalysisJpaRepository.findAverageScoreByCollaboratorIdAndPeriod(collaboratorId, start, end).orElse(null);
     }
 }

--- a/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
+++ b/presentation/src/main/java/com/salespilot/api/presentation/controller/DashboardController.java
@@ -128,7 +128,7 @@ public class DashboardController {
         return ResponseEntity.ok(getGroupedCompaniesCountUseCase.execute());
     }
 
-    @Operation(summary = "Buscar as métricas dos cards de dashboard", description = "Retorna as métricas dos cards de dashboard.")
+    @Operation(summary = "Buscar as métricas dos cards de dashboard", description = "Retorna as métricas dos cards de dashboard de acordo com o papel do usuário. No contexto de vendedor, inclui total de reuniões, duração média e sentimento médio.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Métricas retornadas", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AdminGroupCardMetricsResponseDTO.class))),
             @ApiResponse(responseCode = "400", description = "Período inválido", content = @Content),


### PR DESCRIPTION
## Issue relacionada

<!-- Link da issue no GitHub. -->
Demanda do time: no contexto de vendedor, `GET /api/dashboard/metrics?period=` não retornava o sentimento médio, que é uma das métricas do vendedor.

## O que foi implementado?

O card de métricas do dashboard no **contexto de vendedor** passa a incluir o **sentimento médio**, ao lado de total de reuniões e duração média.

- Calcula a média do `score` de sentimento das pós-análises das reuniões do vendedor no período (`all`/`30d`/`90d`/`custom`).
- Retorna no mesmo formato dos demais cards — `value`, `variationPercent` e `trend` (`up`/`down`/`neutral`) —, comparando o período atual com o anterior.
- Quando não há pós-análise no período, o sentimento médio é `0.0` com tendência `neutral` (sem quebrar).

Camadas (seguindo o padrão do projeto):
- `MeetingPostAnalysisRepository.getAverageFeelingByCollaboratorAndPeriod` + native query `findAverageScoreByCollaboratorIdAndPeriod` (espelha a query já existente `findAverageScoreByCollaboratorId`, adicionando o filtro `m.created_at BETWEEN :start AND :end`, mesmo critério de período usado nos demais cards do vendedor).
- Novo DTO `SentimentCardMetricsResponseDTO` (valor `Double`, mantendo a escala do `averageFeeling` já exposto na listagem de vendedores).
- `SellerGroupCardMetricsResponseDTO` passa a ter o campo `averageSentiment`.
- `GetCardMetricsUseCase` injeta `MeetingPostAnalysisRepository` e monta o card de sentimento (variação calculada em `Double`).

Exemplo de resposta (vendedor):

```json
{
  "total_meetings":    { "value": 12,  "variation_percent": 20.0, "trend": "up" },
  "average_duration":  { "value": 1800, "variation_percent": 0.0,  "trend": "neutral" },
  "average_sentiment": { "value": 0.81, "variation_percent": 8.0,  "trend": "up" }
}
```

## Por que essa mudança é necessária?

O sentimento médio é uma das métricas do vendedor exibidas no dashboard, mas o endpoint de métricas não o retornava no contexto de vendedor — bloqueando o card no frontend.

## Como testar?

1. Autenticar como `SELLER`.
2. `GET /api/dashboard/metrics?period=30d` → conferir o campo `average_sentiment` com `value`, `variation_percent` e `trend`.
3. `GET /api/dashboard/metrics?period=custom&start_date=2026-01-01&end_date=2026-06-30`.
4. Vendedor sem pós-análise no período → `average_sentiment.value = 0.0` e `trend = "neutral"`.
5. `period` inválido deve retornar `400`.

Testes automatizados (`GetCardMetricsUseCaseTest`):
- card de sentimento com tendência calculada;
- default `0.0`/`neutral` quando não há pós-análise no período;
- testes existentes de admin/manager/seller seguem passando.

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [x] Testes foram adicionados ou atualizados para cobrir as mudanças
